### PR TITLE
Use UTC time for 'expires' field in policy, and shorten the duration (for security)

### DIFF
--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -37,7 +37,7 @@ def create_upload_data(content_type, key):
     region = getattr(settings, 'S3DIRECT_REGION', None)
     endpoint = REGIONS.get(region, 's3.amazonaws.com')
 
-    expires_in = datetime.now() + timedelta(hours=5)
+    expires_in = datetime.utcnow() + timedelta(seconds=60*5)
     expires = expires_in.strftime('%Y-%m-%dT%H:%M:%S.000Z')
 
     policy_object = json.dumps({


### PR DESCRIPTION
Love the package, this is a small fix.  I was experiencing Policy Expired errors from AWS.  I'm in Central time (UTC-6hrs).  Amazon is expecting an 'expires' field in UTC.  The old code would use local time, and add 5 hrs, which would work for Europe and East Cost US, but would fail elsewhere.  
