### PR TITLE
add cache control and content disposition to s3 upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ S3DIRECT_DESTINATIONS = {
         lambda u: u.is_authenticated(),
         '*',
         'private')
+
+    # Allow authenticated users to upload with cache-control for a month and content-disposition set to attachment
+    'cached': (
+        'uploads/vids', 
+        lambda u: u.is_authenticated(), 
+        '*', 
+        'public-read', 
+        AWS_STORAGE_BUCKET_NAME, 
+        'max-age=2592000', 
+        'attachment')
 }
 ```
 

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -26,6 +26,8 @@ def get_upload_params(request):
     allowed = get_at(2, dest)
     acl = get_at(3, dest)
     bucket = get_at(4, dest)
+    cache_control = get_at(5, dest)
+    content_disposition = get_at(6, dest)
 
     if not acl:
         acl = 'public-read'
@@ -47,6 +49,6 @@ def get_upload_params(request):
     else:
         key = '%s/${filename}' % key
 
-    data = create_upload_data(content_type, key, acl, bucket)
+    data = create_upload_data(content_type, key, acl, bucket, cache_control, content_disposition)
 
     return HttpResponse(json.dumps(data), content_type="application/json")


### PR DESCRIPTION
Needed a way to set cache control and content disposition automatically.

If this is ok, we should probably make the settings tuple into a dict, since its gotten so big