### PR TITLE
Fix syntax error

### DIFF
--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -47,7 +47,7 @@ def get_upload_params(request):
     if hasattr(key, '__call__'):
         key = key(filename)
     else:
-        key = '%s/${filename}' % key
+        key = '{key}/{filename}'.format(key=key, filename=filename)
 
     data = create_upload_data(content_type, key, acl, bucket, cache_control, content_disposition)
 

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -47,7 +47,9 @@ def get_upload_params(request):
     if hasattr(key, '__call__'):
         key = key(filename)
     else:
-        key = '{key}/{filename}'.format(key=key, filename=filename)
+        # The literal string '${filename}' is an S3 field variable for key.
+        # https://aws.amazon.com/articles/1434#aws-table
+        key = '%s/${filename}' % key
 
     data = create_upload_data(content_type, key, acl, bucket, cache_control, content_disposition)
 


### PR DESCRIPTION
Previously, given `key='hello'` and `filename='world'` this line would have assigned the string `'hello/${filename}'` instead of `'hello/world'` to the variable `key`.