### PR TITLE
Fixed file names with spaces causing error

### DIFF
--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -62,11 +62,13 @@
         alert(msg)
     }
 
-    var update = function(el, xml) {
+    var update = function(el, xml, name) {
         var link = el.querySelector('.file-link'),
             url  = el.querySelector('.file-url')
 
-        url.value = parseURL(xml)
+        var parsedXML = parseURL(xml);
+        var path = parsedXML.substr(0,parsedXML.lastIndexOf('/')+1);
+        url.value = path+name;
         link.setAttribute('href', url.value)
         link.innerHTML = url.value.split('/').pop()
 
@@ -108,7 +110,7 @@
         request('POST', url, form, {}, el, true, function(status, xml){
             disableSubmit(false)
             if(status !== 201) return error(el, 'Sorry, failed to upload to S3.')
-            update(el, xml)
+            update(el, xml, file.name)
         })
     }
 


### PR DESCRIPTION
If you try to upload a file that has a name with a space in it, the space is converted to a "+" sign in the Django admin page, but it is left as a space on S3. This causes an error when trying to save the admin entry, because the widget attempts to search for the file by its S3 key when saving and cannot find the S3 key. I've fixed this.

In scripts.js, in the update function, I replaced
url.value = parseURL(xml)
with

var parsedXML = parseURL(xml);
var path = parsedXML.substr(0,parsedXML.lastIndexOf('/')+1);
url.value = path+name;

and added a parameter called "name" to the update function. Then at the end of the upload function in the same file, I added the variable called "file.name" as a third parameter to the update function call.  These changes maintain the space in the file name in the Django admin instead of converting it to a + sign, so that when this name is compared with the name in S3, they are the same.  I have been using this change on our servers for the past few months and have not encountered any issue with the change, but I would not rule out the possibility that there is some consequence that I have not foreseen.
