### PR TITLE
Allow the user to specify a custom HTML template for the S3DirectWidget

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,29 @@ class S3DirectUploadForm(forms.Form):
     images = forms.URLField(widget=S3DirectWidget(dest='destination_key_from_settings'))
 ```
 
+You can create a custom template by passing in a string with your own HTML to the `html` keyword argument. For example:
+
+```python
+from django import forms
+from s3direct.widgets import S3DirectWidget
+
+class S3DirectUploadForm(forms.Form):
+    images = forms.URLField(widget=S3DirectWidget(
+        dest='destination_key_from_settings'
+        html=(
+            '<div class="s3direct" data-policy-url="{policy_url}">'
+            '  <a class="file-link" target="_blank" href="{file_url}">{file_name}</a>'
+            '  <a class="file-remove" href="#remove">Remove</a>'
+            '  <input class="file-url" type="hidden" value="{file_url}" id="{element_id}" name="{name}" />'
+            '  <input class="file-dest" type="hidden" value="{dest}">'
+            '  <input class="file-input" type="file" />'
+            '  <div class="progress progress-striped active">'
+            '    <div class="bar"></div>'
+            '  </div>'
+            '</div>'
+        )))
+```
+
 ### views.py
 
 ```python

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -8,7 +8,7 @@ from django.conf import settings
 
 class S3DirectWidget(widgets.TextInput):
 
-    html = (
+    default_html = (
         '<div class="s3direct" data-policy-url="{policy_url}">'
         '  <a class="file-link" target="_blank" href="{file_url}">{file_name}</a>'
         '  <a class="file-remove" href="#remove">Remove</a>'
@@ -34,6 +34,7 @@ class S3DirectWidget(widgets.TextInput):
 
     def __init__(self, *args, **kwargs):
         self.dest = kwargs.pop('dest', None)
+        self.html = kwargs.pop('dest', self.default_html)
         super(S3DirectWidget, self).__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None):

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -34,7 +34,7 @@ class S3DirectWidget(widgets.TextInput):
 
     def __init__(self, *args, **kwargs):
         self.dest = kwargs.pop('dest', None)
-        self.html = kwargs.pop('dest', self.default_html)
+        self.html = kwargs.pop('html', self.default_html)
         super(S3DirectWidget, self).__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None):


### PR DESCRIPTION
For example, you can change the layout, classnames, and so on to implement a custom design / CSS.