### PR TITLE
Fix deprecation warnings in URL conf

### DIFF
--- a/s3direct/urls.py
+++ b/s3direct/urls.py
@@ -1,7 +1,6 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from s3direct.views import get_upload_params
 
-urlpatterns = patterns('',
-                       url('^get_upload_params/',
-                           get_upload_params, name='s3direct'),
-                       )
+urlpatterns = [
+    url('^get_upload_params/', get_upload_params, name='s3direct')
+]


### PR DESCRIPTION
After upgrading to Django 1.9 warnings are thrown from the URL conf:

```
~/.virtualenvs/proj/lib/python3.4/site-packages/s3direct/urls.py:6: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  get_upload_params, name='s3direct'),
```