### PR TITLE
Makes destination a dict instead of a tuple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/*
 venv
 example/db.sqlite3
 /build
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 dist/*
 *.egg-info
 venv
+venv3
 example/db.sqlite3
 /build
 .idea

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ S3DIRECT_REGION = 'us-east-1'
 # 'destination_key' is the key to use for the 'dest' attribute on your widget or model field
 S3DIRECT_DESTINATIONS = {
     # Allow anybody to upload any MIME type
-    'misc': ('uploads/misc',),
+    'misc': {'key': 'uploads/misc',},
 
     # Allow staff users to upload any MIME type
     'files': {'key': 'uploads/files', 'auth': lambda u: u.is_staff,},
@@ -89,7 +89,7 @@ S3DIRECT_DESTINATIONS = {
         'key': 'uploads/vids',
         'auth': lambda u: u.is_authenticated(),
         'allowed': '*',
-        'acl': 'private'}
+        'acl': 'private'},
 
     # Allow authenticated users to upload with cache-control for a month and content-disposition set to attachment
     'cached': {
@@ -99,10 +99,10 @@ S3DIRECT_DESTINATIONS = {
         'acl': 'public-read', 
         'bucket': AWS_STORAGE_BUCKET_NAME, 
         'cache_control': 'max-age=2592000', 
-        'content_disposition': 'attachment'}
+        'content_disposition': 'attachment'},
 }
 ```
-NOTE: See past README versions for, older, "positional" style destination settings.
+NOTE: See past README versions for older "positional" style destination settings.
 
 ### urls.py
 

--- a/README.md
+++ b/README.md
@@ -70,38 +70,39 @@ S3DIRECT_DESTINATIONS = {
     'misc': ('uploads/misc',),
 
     # Allow staff users to upload any MIME type
-    'files': ('uploads/files', lambda u: u.is_staff,),
+    'files': {'key': 'uploads/files', 'auth': lambda u: u.is_staff,},
 
     # Allow anybody to upload jpeg's and png's.
-    'imgs': ('uploads/imgs', lambda u: True, ['image/jpeg', 'image/png'],),
+    'imgs': {'key': 'uploads/imgs', 'auth': lambda u: True, 'allowed': ['image/jpeg', 'image/png'],},
 
     # Allow authenticated users to upload mp4's
-    'vids': ('uploads/vids', lambda u: u.is_authenticated(), ['video/mp4'],),
+    'vids': {'key': 'uploads/vids', 'auth': lambda u: u.is_authenticated(), 'allowed': ['video/mp4'],},
 
     # Allow anybody to upload any MIME type with a custom name function, eg:
-    'custom_filename': (lambda original_filename: 'images/unique.jpg',),
+    'custom_filename': {'key': lambda original_filename: 'images/unique.jpg',},
 
     # Specify a non-default bucket for PDFs
-    'pdfs': ('/', lambda u: True, ['application/pdf'], None, 'pdf-bucket',),
+    'pdfs': {'key': '/', 'auth': lambda u: True, 'allowed': ['application/pdf'], 'acl': None, 'bucket': 'pdf-bucket',},
 
     # Allow logged in users to upload any type of file and give it a private acl:
-    'private': (
-        'uploads/vids',
-        lambda u: u.is_authenticated(),
-        '*',
-        'private')
+    'private': {
+        'key': 'uploads/vids',
+        'auth': lambda u: u.is_authenticated(),
+        'allowed': '*',
+        'acl': 'private'}
 
     # Allow authenticated users to upload with cache-control for a month and content-disposition set to attachment
-    'cached': (
-        'uploads/vids', 
-        lambda u: u.is_authenticated(), 
-        '*', 
-        'public-read', 
-        AWS_STORAGE_BUCKET_NAME, 
-        'max-age=2592000', 
-        'attachment')
+    'cached': {
+        'key': 'uploads/vids', 
+        'auth': lambda u: u.is_authenticated(), 
+        'allowed': '*', 
+        'acl': 'public-read', 
+        'bucket': AWS_STORAGE_BUCKET_NAME, 
+        'cache_control': 'max-age=2592000', 
+        'content_disposition': 'attachment'}
 }
 ```
+NOTE: See past README versions for, older, "positional" style destination settings.
 
 ### urls.py
 

--- a/runtests.py
+++ b/runtests.py
@@ -45,6 +45,15 @@ settings.configure(DEBUG=True,
                            'auth': lambda u: u.is_authenticated(),
                            'allowed': ['video/mp4'],
                        },
+                       'cached': {
+                           'key': 'uploads/vids',
+                           'auth': lambda u: True,
+                           'allowed': '*',
+                           'acl': 'authenticated-read',
+                           'bucket': 'astoragebucketname',
+                           'cache_control': 'max-age=2592000',
+                           'content_disposition': 'attachment',
+                       }
                    })
 
 if hasattr(django, 'setup'):

--- a/runtests.py
+++ b/runtests.py
@@ -27,10 +27,24 @@ settings.configure(DEBUG=True,
                                 'test-bucket'),
                    S3DIRECT_REGION='us-east-1',
                    S3DIRECT_DESTINATIONS={
-                       'misc': (lambda original_filename: 'images/unique.jpg',),
-                       'files': ('uploads/files', lambda u: u.is_staff,),
-                       'imgs': ('uploads/imgs', lambda u: True, ['image/jpeg', 'image/png'],),
-                       'vids': ('uploads/vids', lambda u: u.is_authenticated(), ['video/mp4'],)
+                       'misc': {
+                           'key': lambda original_filename:
+                           'images/unique.jpg',
+                       },
+                       'files': {
+                           'key': 'uploads/files',
+                           'auth': lambda u: u.is_staff,
+                       },
+                       'imgs': {
+                           'key': 'uploads/imgs',
+                           'auth': lambda u: True,
+                           'allowed': ['image/jpeg', 'image/png'],
+                       },
+                       'vids': {
+                           'key': 'uploads/vids',
+                           'auth': lambda u: u.is_authenticated(),
+                           'allowed': ['video/mp4'],
+                       },
                    })
 
 if hasattr(django, 'setup'):

--- a/runtests.py
+++ b/runtests.py
@@ -28,8 +28,7 @@ settings.configure(DEBUG=True,
                    S3DIRECT_REGION='us-east-1',
                    S3DIRECT_DESTINATIONS={
                        'misc': {
-                           'key': lambda original_filename:
-                           'images/unique.jpg',
+                           'key': lambda original_filename: 'images/unique.jpg',
                        },
                        'files': {
                            'key': 'uploads/files',

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -81,13 +81,13 @@ class WidgetTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def check_disallowed_type_logged_out(self):
-        data = {'dest': 'vids', 'name': 'video.mp4', 'type': 'video/mp4'}
+        data = {u'dest': u'vids', u'name': u'video.mp4', u'type': u'video/mp4'}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 403)
 
     def check_signing_fields(self):
         self.client.login(username='admin', password='admin')
-        data = {'dest': 'imgs', 'name': 'image.jpg', 'type': 'image/jpeg'}
+        data = {u'dest': u'imgs', u'name': u'image.jpg', u'type': u'image/jpeg'}
         response = self.client.post(reverse('s3direct'), data)
         response_dict = json.loads(response.content.decode())
         self.assertTrue(u'x-amz-signature' in response_dict)
@@ -96,7 +96,7 @@ class WidgetTestCase(TestCase):
         self.assertDictContainsSubset(FOO_RESPONSE, response_dict)
 
     def check_signing_fields_unique_filename(self):
-        data = {'dest': 'misc', 'name': 'image.jpg', 'type': 'image/jpeg'}
+        data = {u'dest': u'misc', u'name': u'image.jpg', u'type': u'image/jpeg'}
         response = self.client.post(reverse('s3direct'), data)
         response_dict = json.loads(response.content.decode())
         self.assertTrue(u'x-amz-credential' in response_dict)
@@ -108,13 +108,13 @@ class WidgetTestCase(TestCase):
 
     def check_policy_conditions(self):
         self.client.login(username='admin', password='admin')
-        data = {'dest': 'cached', 'name': 'video.mp4', 'type': 'video/mp4'}
+        data = {u'dest': u'cached', u'name': u'video.mp4', u'type': u'video/mp4'}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 200)
 
         response_dict = json.loads(response.content.decode())
         self.assertTrue('policy' in response_dict)
-        policy_dict = json.loads(b64decode(response_dict['policy']))
+        policy_dict = json.loads(b64decode(response_dict['policy']).decode('utf-8'))
         self.assertTrue('conditions' in policy_dict)
         conditions_dict = policy_dict['conditions']
         self.assertEqual(conditions_dict[0]['bucket'], u'astoragebucketname')

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -31,54 +31,60 @@ FOO_RESPONSE = {
 }
 
 
-class WidgetTest(TestCase):
+class WidgetTestCase(TestCase):
+    """
+    This allows us to have 2 version of the same tests but with different settings.
+    As opposed to inheriting test methods as doing that makes the failure stack hard to parse.
+    TODO: Get rid of this base class and the appropriate subclass when positional setting support is dropped. See #48
+    """
+    
     def setUp(self):
         admin = User.objects.create_superuser('admin', 'u@email.com', 'admin')
         admin.save()
-
-    def test_urls(self):
+        
+    def check_urls(self):
         reversed_url = reverse('s3direct')
         resolved_url = resolve('/get_upload_params/')
         self.assertEqual(reversed_url, '/get_upload_params/')
         self.assertEqual(resolved_url.view_name, 's3direct')
-
-    def test_widget_html(self):
+        
+    def check_widget_html(self):
         widget = widgets.S3DirectWidget(dest='foo')
         self.assertEqual(widget.render('filename', None), HTML_OUTPUT)
 
-    def test_signing_logged_in(self):
+    def check_signing_logged_in(self):
         self.client.login(username='admin', password='admin')
         data = {'dest': 'files', 'name': 'image.jpg', 'type': 'image/jpeg'}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 200)
 
-    def test_signing_logged_out(self):
+    def check_signing_logged_out(self):
         data = {'dest': 'files', 'name': 'image.jpg', 'type': 'image/jpeg'}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 403)
 
-    def test_allowed_type(self):
+    def check_allowed_type(self):
         data = {'dest': 'imgs', 'name': 'image.jpg', 'type': 'image/jpeg'}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 200)
 
-    def test_disallowed_type(self):
+    def check_disallowed_type(self):
         data = {'dest': 'imgs', 'name': 'image.mp4', 'type': 'video/mp4'}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 400)
 
-    def test_allowed_type_logged_in(self):
+    def check_allowed_type_logged_in(self):
         self.client.login(username='admin', password='admin')
         data = {'dest': 'vids', 'name': 'video.mp4', 'type': 'video/mp4'}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 200)
 
-    def test_disallowed_type_logged_out(self):
+    def check_disallowed_type_logged_out(self):
         data = {'dest': 'vids', 'name': 'video.mp4', 'type': 'video/mp4'}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 403)
 
-    def test_signing_fields(self):
+    def check_signing_fields(self):
         self.client.login(username='admin', password='admin')
         data = {'dest': 'imgs', 'name': 'image.jpg', 'type': 'image/jpeg'}
         response = self.client.post(reverse('s3direct'), data)
@@ -88,12 +94,95 @@ class WidgetTest(TestCase):
         self.assertTrue(u'policy' in response_dict)
         self.assertDictContainsSubset(FOO_RESPONSE, response_dict)
 
-    def test_signing_fields_unique_filename(self):
+    def check_signing_fields_unique_filename(self):
         data = {'dest': 'misc', 'name': 'image.jpg', 'type': 'image/jpeg'}
         response = self.client.post(reverse('s3direct'), data)
         response_dict = json.loads(response.content.decode())
         self.assertTrue(u'x-amz-credential' in response_dict)
         self.assertTrue(u'x-amz-credential' in response_dict)
         self.assertTrue(u'policy' in response_dict)
-        FOO_RESPONSE['key'] = 'images/unique.jpg'
-        self.assertDictContainsSubset(FOO_RESPONSE, response_dict)
+        changed = FOO_RESPONSE.copy()
+        changed['key'] = 'images/unique.jpg'
+        self.assertDictContainsSubset(changed, response_dict)
+
+
+@override_settings(S3DIRECT_DESTINATIONS={
+    'misc': (lambda original_filename: 'images/unique.jpg',),
+    'files': ('uploads/files', lambda u: u.is_staff,),
+    'imgs': ('uploads/imgs', lambda u: True, ['image/jpeg', 'image/png'],),
+    'vids': ('uploads/vids', lambda u: u.is_authenticated(), ['video/mp4'],)
+})
+class OldStyleSettingsWidgetTest(WidgetTestCase):
+    """
+    Test coverage for the older "positional" style of specifying settings.
+    TODO: Remove me when positional settings are no longer supported.
+    """
+
+    def setUp(self):
+        super(OldStyleSettingsWidgetTest, self).setUp()
+
+    def test_urls(self):
+        self.check_urls()
+
+    def test_widget_html(self):
+        self.check_widget_html()
+
+    def test_signing_logged_in(self):
+        self.check_signing_logged_in()
+
+    def test_signing_logged_out(self):
+        self.check_signing_logged_out()
+
+    def test_allowed_type(self):
+        self.check_allowed_type()
+
+    def test_disallowed_type(self):
+        self.check_disallowed_type()
+
+    def test_allowed_type_logged_in(self):
+        self.check_allowed_type_logged_in()
+
+    def test_disallowed_type_logged_out(self):
+        self.check_disallowed_type_logged_out()
+
+    def test_signing_fields(self):
+        self.check_signing_fields()
+
+    def test_signing_fields_unique_filename(self):
+        self.check_signing_fields_unique_filename()
+
+
+class WidgetTest(WidgetTestCase):
+    
+    def setUp(self):
+        super(WidgetTest, self).setUp()
+
+    def test_urls(self):
+        self.check_urls()
+
+    def test_widget_html(self):
+        self.check_widget_html()
+
+    def test_signing_logged_in(self):
+        self.check_signing_logged_in()
+
+    def test_signing_logged_out(self):
+        self.check_signing_logged_out()
+
+    def test_allowed_type(self):
+        self.check_allowed_type()
+
+    def test_disallowed_type(self):
+        self.check_disallowed_type()
+
+    def test_allowed_type_logged_in(self):
+        self.check_allowed_type_logged_in()
+
+    def test_disallowed_type_logged_out(self):
+        self.check_disallowed_type_logged_out()
+
+    def test_signing_fields(self):
+        self.check_signing_fields()
+
+    def test_signing_fields_unique_filename(self):
+        self.check_signing_fields_unique_filename()

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -20,6 +20,11 @@ REGIONS = {
 }
 
 
+# NOTE: Don't use constant as it will break ability to change at runtime (E.g. tests)
+def get_s3direct_settings():
+    return getattr(settings, 'S3DIRECT_DESTINATIONS', None)
+
+
 def get_at(index, t):
     try:
         value = t[index]

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -37,10 +37,14 @@ def get_s3direct_destinations():
 
     # TODO: Remove when older "positional" style settings are no longer supported
     converted_destinations = {}
-    key_mapping = {  # FIXME: Code has more but... tests or it didn't happen.
+    key_mapping = {
         0: 'key',
         1: 'auth',
         2: 'allowed',
+        3: 'acl',
+        4: 'bucket',
+        5: 'cache_control',
+        6: 'content_disposition',
     }
     if destinations:
         for dest, dest_value in destinations.items():
@@ -117,6 +121,7 @@ def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
     bucket_url = structure.format(endpoint, bucket)
 
     return_dict = {
+        # FIXME: .decode() does nothing, b64decode works but is decoding really intended?
         "policy": policy.decode(),
         "success_action_status": 201,
         "x-amz-credential": "%s/%s/%s/s3/aws4_request" % (

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -3,7 +3,7 @@ import json
 from django.http import HttpResponse
 from django.views.decorators.http import require_POST
 
-from .utils import create_upload_data, get_at, get_s3direct_settings
+from .utils import create_upload_data, get_s3direct_destinations
 
 
 @require_POST
@@ -11,19 +11,19 @@ def get_upload_params(request):
     content_type = request.POST['type']
     filename = request.POST['name']
 
-    dest = get_s3direct_settings().get(request.POST['dest'])
+    dest = get_s3direct_destinations().get(request.POST['dest'])
 
     if not dest:
         data = json.dumps({'error': 'File destination does not exist.'})
         return HttpResponse(data, content_type="application/json", status=400)
 
-    key = get_at(0, dest)
-    auth = get_at(1, dest)
-    allowed = get_at(2, dest)
-    acl = get_at(3, dest)
-    bucket = get_at(4, dest)
-    cache_control = get_at(5, dest)
-    content_disposition = get_at(6, dest)
+    key = dest.get('key')
+    auth = dest.get('auth')
+    allowed = dest.get('allowed')
+    acl = dest.get('acl')
+    bucket = dest.get('bucket')
+    cache_control = dest.get('cache_control')
+    content_disposition = dest.get('content_disposition')
 
     if not acl:
         acl = 'public-read'

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -2,12 +2,8 @@ import json
 
 from django.http import HttpResponse
 from django.views.decorators.http import require_POST
-from django.conf import settings
 
-from .utils import create_upload_data, get_at
-
-
-DESTINATIONS = getattr(settings, 'S3DIRECT_DESTINATIONS', None)
+from .utils import create_upload_data, get_at, get_s3direct_settings
 
 
 @require_POST
@@ -15,7 +11,7 @@ def get_upload_params(request):
     content_type = request.POST['type']
     filename = request.POST['name']
 
-    dest = DESTINATIONS.get(request.POST['dest'])
+    dest = get_s3direct_settings().get(request.POST['dest'])
 
     if not dest:
         data = json.dumps({'error': 'File destination does not exist.'})

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -3,7 +3,6 @@ import os
 from django.forms import widgets
 from django.utils.safestring import mark_safe
 from django.core.urlresolvers import reverse
-from django.conf import settings
 
 
 class S3DirectWidget(widgets.TextInput):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='django-s3direct',
-    version='0.3.15',
+    version='0.4.0',
     description='Add direct uploads to S3 functionality with a progress bar to file input fields.',
     long_description=readme,
     author="Bradley Griffiths",


### PR DESCRIPTION
Closes #48 

This adds support for both destinations specified in dict format (new way) as well as the older positional way. It also adds test coverage for the policy conditions code.

The # of tests have been doubled in order to test both old and new style settings. I ran the tests under Django 1.6.2, 1.7, 1.8 and 1.9 on my system. I also manual tested (locally) in one of my projects. The docs have been updated to have the new style.

I didn't add deprecation warnings for those using the old way as I figure that can be added later when the version where it's no longer supported is decided.

As an aside, I found an [interesting little wart that I am not sure is safe to remove](https://github.com/bradleyg/django-s3direct/compare/master...WimpyAnalytics:dictsettings48?expand=1#diff-0f7d915c6818496954ed0944f1998c36R124) (and doesn't pertain to this PR). 