### PR TITLE
UTF8 file names handling

### DIFF
--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -35,9 +35,13 @@
     var parseURL = function(text) {
         var xml = new DOMParser().parseFromString(text, 'text/xml'),
             tag = xml.getElementsByTagName('Location')[0],
-            url = unescape(tag.childNodes[0].nodeValue)
+            url = tag.childNodes[0].nodeValue
 
-        return url
+        return url;
+    }
+
+    var parseNameFromUrl = function(url) {
+        return decodeURIComponent((url + '').replace(/\+/g, '%20'));
     }
 
     var parseJson = function(json) {
@@ -68,7 +72,7 @@
 
         url.value = parseURL(xml)
         link.setAttribute('href', url.value)
-        link.innerHTML = url.value.split('/').pop()
+        link.innerHTML = parseNameFromUrl(url.value).split('/').pop();
 
         el.className = 's3direct link-active'
         el.querySelector('.bar').style.width = '0%'

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -1,8 +1,10 @@
-import os
+from __future__ import unicode_literals
 
+import os
 from django.forms import widgets
 from django.utils.safestring import mark_safe
 from django.core.urlresolvers import reverse
+from django.utils.http import urlunquote_plus
 
 
 class S3DirectWidget(widgets.TextInput):
@@ -37,10 +39,14 @@ class S3DirectWidget(widgets.TextInput):
         super(S3DirectWidget, self).__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None):
+        if value:
+            file_name = os.path.basename(urlunquote_plus(value))
+        else:
+            file_name = ''
         output = self.html.format(
             policy_url=reverse('s3direct'),
             element_id=self.build_attrs(attrs).get('id'),
-            file_name=os.path.basename(value or ''),
+            file_name=file_name,
             dest=self.dest,
             file_url=value or '',
             name=name)

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -10,7 +10,7 @@ from django.utils.http import urlunquote_plus
 class S3DirectWidget(widgets.TextInput):
 
     default_html = (
-        '<div class="s3direct" data-policy-url="{policy_url}">'
+        '<div class="s3direct" data-policy-url="{policy_url}" style="{style}">'
         '  <a class="file-link" target="_blank" href="{file_url}">{file_name}</a>'
         '  <a class="file-remove" href="#remove">Remove</a>'
         '  <input class="file-url" type="hidden" value="{file_url}" id="{element_id}" name="{name}" />'
@@ -43,12 +43,14 @@ class S3DirectWidget(widgets.TextInput):
             file_name = os.path.basename(urlunquote_plus(value))
         else:
             file_name = ''
+
         output = self.html.format(
             policy_url=reverse('s3direct'),
             element_id=self.build_attrs(attrs).get('id'),
             file_name=file_name,
             dest=self.dest,
             file_url=value or '',
-            name=name)
+            name=name,
+            style=self.build_attrs(attrs).get('style'))
 
         return mark_safe(output)

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -10,12 +10,12 @@ from django.utils.http import urlunquote_plus
 class S3DirectWidget(widgets.TextInput):
 
     default_html = (
-        '<div class="s3direct" data-policy-url="{policy_url}" style="{style}">'
+        '<div class="s3direct" data-policy-url="{policy_url}">'
         '  <a class="file-link" target="_blank" href="{file_url}">{file_name}</a>'
         '  <a class="file-remove" href="#remove">Remove</a>'
         '  <input class="file-url" type="hidden" value="{file_url}" id="{element_id}" name="{name}" />'
         '  <input class="file-dest" type="hidden" value="{dest}">'
-        '  <input class="file-input" type="file" />'
+        '  <input class="file-input" type="file"  style="{style}"/>'
         '  <div class="progress progress-striped active">'
         '    <div class="bar"></div>'
         '  </div>'


### PR DESCRIPTION
There was a bug with file names that contained spaces and utf8 characters. It was making the `render` throw an exception, and it wasn't handled correctly when it was uploaded earlier. 

This changes the way we store the urls, we now store it exactly how it comes back from S3, and `urlunquote_plus()` when we show them. 

I don't know how to unit test this, i've done a lot of manual testing of it though
