### PR TITLE
Upload size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ S3DIRECT_DESTINATIONS = {
         'cache_control': 'max-age=2592000', 
         'content_disposition': 'attachment'
     },
+    
+    # Limit size of uploads to a min and max size range (in bytes)
+    'example9': {
+        'content_length_range': (5000, 20000000),
+    },
 }
 ```
 NOTE: See past README versions for older "positional" style destination settings.

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -124,10 +124,13 @@ S3DIRECT_DESTINATIONS = {
     # Allow staff users to upload any MIME type
     'pdfs': {'key': '/uploads/pdfs', 'auth': lambda u: u.is_staff,},
 
-    # Allow anybody to upload jpeg's and png's.
-    'images': {'key': '/uploads/images', 'auth': lambda u: True, 'allowed': [
-        'image/jpeg',
-        'image/png']
+    # Allow anybody to upload jpeg's and png's. Limit sizes to 5kb - 20mb
+    'images': {
+        'key': '/uploads/images', 'auth': lambda u: True, 'allowed': [
+            'image/jpeg',
+            'image/png'
+        ],
+        'content_length_range': (5000, 20000000),
     },
 
     # Allow authenticated users to upload mp4's

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -119,22 +119,22 @@ def create_filename(filename):
 
 S3DIRECT_DESTINATIONS = {
     # Allow anybody to upload any MIME type
-    'misc': ('/',),
+    'misc': {'key': '/'},
 
     # Allow staff users to upload any MIME type
-    'pdfs': ('/uploads/pdfs', lambda u: u.is_staff,),
+    'pdfs': {'key': '/uploads/pdfs', 'auth': lambda u: u.is_staff,},
 
     # Allow anybody to upload jpeg's and png's.
-    'images': ('/uploads/images', lambda u: True, [
+    'images': {'key': '/uploads/images', 'auth': lambda u: True, 'allowed': [
         'image/jpeg',
         'image/png']
-    ),
+    },
 
     # Allow authenticated users to upload mp4's
-    'videos': ('/uploads/videos', lambda u: u.is_authenticated(), [
+    'videos': {'key': '/uploads/videos', 'auth': lambda u: u.is_authenticated(), 'allowed': [
         'video/mp4'
-    ]),
+    ]},
 
     # Allow anybody to upload any MIME type with a custom name function
-    'custom_filename': (create_filename,),
+    'custom_filename': {'key': create_filename,},
 }

--- a/runtests.py
+++ b/runtests.py
@@ -38,6 +38,7 @@ settings.configure(DEBUG=True,
                            'key': 'uploads/imgs',
                            'auth': lambda u: True,
                            'allowed': ['image/jpeg', 'image/png'],
+                           'content_length_range': (5000, 20000000),  # 5kb - 20mb
                        },
                        'vids': {
                            'key': 'uploads/vids',

--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -107,7 +107,16 @@
 
         request('POST', url, form, {}, el, true, function(status, xml){
             disableSubmit(false)
-            if(status !== 201) return error(el, 'Sorry, failed to upload to S3.')
+            if(status !== 201) {
+                if (xml.indexOf('<MinSizeAllowed>') > -1) {
+                    return error(el, 'Sorry, the file is too small to be uploaded.')
+                }
+                else if (xml.indexOf('<MaxSizeAllowed>') > -1) {
+                    return error(el, 'Sorry, the file is too large to be uploaded.')
+                }
+
+                return error(el, 'Sorry, failed to upload file.')
+            }
             update(el, xml)
         })
     }

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -211,3 +211,17 @@ class WidgetTest(WidgetTestCase):
 
     def test_policy_conditions(self):
         self.check_policy_conditions()
+
+    """Tests for features only available with new-style settings"""
+    def test_content_length_range(self):
+        # Content_length_range setting is always sent as part of policy. Initial request data doesn't affect it.
+        data = {'dest': 'imgs', 'name': 'image.jpg', 'type': 'image/jpeg'}
+        response = self.client.post(reverse('s3direct'), data)
+        self.assertEqual(response.status_code, 200)
+
+        response_dict = json.loads(response.content.decode())
+        self.assertTrue('policy' in response_dict)
+        policy_dict = json.loads(b64decode(response_dict['policy']).decode('utf-8'))
+        self.assertTrue('conditions' in policy_dict)
+        conditions_dict = policy_dict['conditions']
+        self.assertEqual(conditions_dict[-1], ['content-length-range', 5000, 20000000])

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -59,7 +59,7 @@ def get_s3direct_destinations():
 
 
 def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
-                       content_disposition=None):
+                       content_disposition=None, content_length_range=None):
     access_key = settings.AWS_ACCESS_KEY_ID
     secret_access_key = settings.AWS_SECRET_ACCESS_KEY
     bucket = bucket or settings.AWS_STORAGE_BUCKET_NAME
@@ -95,6 +95,11 @@ def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
         policy_dict['conditions'].append({
             'Content-Disposition': content_disposition
         })
+
+    if content_length_range:
+        policy_dict['conditions'].append(
+            ['content-length-range', content_length_range[0], content_length_range[1]]
+        )
 
     policy_object = json.dumps(policy_dict)
 

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -24,6 +24,7 @@ def get_upload_params(request):
     bucket = dest.get('bucket')
     cache_control = dest.get('cache_control')
     content_disposition = dest.get('content_disposition')
+    content_length_range = dest.get('content_length_range')
 
     if not acl:
         acl = 'public-read'
@@ -50,6 +51,6 @@ def get_upload_params(request):
         key = '%s/${filename}' % key
 
     data = create_upload_data(
-        content_type, key, acl, bucket, cache_control, content_disposition)
+        content_type, key, acl, bucket, cache_control, content_disposition, content_length_range)
 
     return HttpResponse(json.dumps(data), content_type="application/json")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='django-s3direct',
-    version='0.4.0',
+    version='0.4.1',
     description='Add direct uploads to S3 functionality with a progress bar to file input fields.',
     long_description=readme,
     author="Bradley Griffiths",


### PR DESCRIPTION
Closes #62 by allowing a min and max size range for uploaded files. 

* (optional) Feature is only available in new style settings
* Enforced by way of S3 [content-length-range](http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html).
* The JS error alert has been updated to look for min/max size errors from S3 in order to give a more informative message.
* Updates the example app to use the new style settings.
