### PR TITLE
Add support for x-amz-server-side-encryption header

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ S3DIRECT_REGION = 'us-east-1'
 # cache_control [optional] Cache control headers, eg 'max-age=2592000'
 # content_disposition [optional] Useful for sending files as attachements
 # bucket [optional] Specify a different bucket for this particular object
+# server_side_encryption [optional] Encryption headers for buckets that require it
 #
 S3DIRECT_DESTINATIONS = {
     # Allow anybody to upload any MIME type
@@ -77,20 +78,20 @@ S3DIRECT_DESTINATIONS = {
 
     # Allow staff users to upload any MIME type
     'example2': {
-        'key': 'uploads/files', 
+        'key': 'uploads/files',
         'auth': lambda u: u.is_staff,
     },
 
     # Limit uploads to jpeg's and png's.
     'example3': {
-        'key': 'uploads/imgs', 
+        'key': 'uploads/imgs',
         'allowed': ['image/jpeg', 'image/png'],
     },
 
     # Allow authenticated users to upload mp4's
     'example4': {
-        'key': 'uploads/vids', 
-        'auth': lambda u: u.is_authenticated(), 
+        'key': 'uploads/vids',
+        'auth': lambda u: u.is_authenticated(),
         'allowed': ['video/mp4'],
     },
 
@@ -101,7 +102,7 @@ S3DIRECT_DESTINATIONS = {
 
     # Specify a non-default bucket for this object
     'example6': {
-        'key': '/', 
+        'key': '/',
         'bucket': 'pdf-bucket',
     },
 
@@ -114,13 +115,18 @@ S3DIRECT_DESTINATIONS = {
     # Set custom cache control and content disposition headers.
     'example8': {
         'key': 'uploads/vids',
-        'cache_control': 'max-age=2592000', 
+        'cache_control': 'max-age=2592000',
         'content_disposition': 'attachment'
     },
-    
+
     # Limit size of uploads to a min and max size range (in bytes)
     'example9': {
         'content_length_range': (5000, 20000000),
+    },
+
+    # Specify encryption header for buckets that require it.
+    'example10': {
+        'server_side_encryption': 'AES256',
     },
 }
 ```

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -38,17 +38,17 @@ class WidgetTestCase(TestCase):
     As opposed to inheriting test methods as doing that makes the failure stack hard to parse.
     TODO: Get rid of this base class and the appropriate subclass when positional setting support is dropped. See #48
     """
-    
+
     def setUp(self):
         admin = User.objects.create_superuser('admin', 'u@email.com', 'admin')
         admin.save()
-        
+
     def check_urls(self):
         reversed_url = reverse('s3direct')
         resolved_url = resolve('/get_upload_params/')
         self.assertEqual(reversed_url, '/get_upload_params/')
         self.assertEqual(resolved_url.view_name, 's3direct')
-        
+
     def check_widget_html(self):
         widget = widgets.S3DirectWidget(dest='foo')
         self.assertEqual(widget.render('filename', None), HTML_OUTPUT)
@@ -121,6 +121,7 @@ class WidgetTestCase(TestCase):
         self.assertEqual(conditions_dict[1]['acl'], u'authenticated-read')
         self.assertEqual(conditions_dict[8]['Cache-Control'], u'max-age=2592000')
         self.assertEqual(conditions_dict[9]['Content-Disposition'], u'attachment')
+        self.assertEqual(conditions_dict[10]['x-amz-server-side-encryption'], u'AES256')
 
 
 @override_settings(S3DIRECT_DESTINATIONS={
@@ -129,7 +130,8 @@ class WidgetTestCase(TestCase):
     'imgs': ('uploads/imgs', lambda u: True, ['image/jpeg', 'image/png'],),
     'vids': ('uploads/vids', lambda u: u.is_authenticated(), ['video/mp4'],),
     'cached': ('uploads/vids', lambda u: u.is_authenticated(), '*', 'authenticated-read',
-               'astoragebucketname', 'max-age=2592000', 'attachment',),
+               'astoragebucketname', 'max-age=2592000', 'attachment',
+               'AES256'),
 })
 class OldStyleSettingsWidgetTest(WidgetTestCase):
     """
@@ -175,7 +177,7 @@ class OldStyleSettingsWidgetTest(WidgetTestCase):
 
 
 class WidgetTest(WidgetTestCase):
-    
+
     def setUp(self):
         super(WidgetTest, self).setUp()
 

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -45,6 +45,7 @@ def get_s3direct_destinations():
         4: 'bucket',
         5: 'cache_control',
         6: 'content_disposition',
+        7: 'server_side_encryption',
     }
     if destinations:
         for dest, dest_value in destinations.items():
@@ -59,7 +60,8 @@ def get_s3direct_destinations():
 
 
 def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
-                       content_disposition=None, content_length_range=None):
+                       content_disposition=None, content_length_range=None,
+                       server_side_encryption=None):
     access_key = settings.AWS_ACCESS_KEY_ID
     secret_access_key = settings.AWS_SECRET_ACCESS_KEY
     bucket = bucket or settings.AWS_STORAGE_BUCKET_NAME
@@ -95,6 +97,11 @@ def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
         policy_dict['conditions'].append({
             'Content-Disposition': content_disposition
         })
+
+    if server_side_encryption:
+        policy_dict['conditions'].append(
+            {'x-amz-server-side-encryption': server_side_encryption}
+        )
 
     if content_length_range:
         policy_dict['conditions'].append(

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -25,6 +25,7 @@ def get_upload_params(request):
     cache_control = dest.get('cache_control')
     content_disposition = dest.get('content_disposition')
     content_length_range = dest.get('content_length_range')
+    server_side_encryption = dest.get('server_side_encryption')
 
     if not acl:
         acl = 'public-read'
@@ -51,6 +52,8 @@ def get_upload_params(request):
         key = '%s/${filename}' % key
 
     data = create_upload_data(
-        content_type, key, acl, bucket, cache_control, content_disposition, content_length_range)
+        content_type, key, acl, bucket, cache_control, content_disposition, content_length_range,
+        server_side_encryption
+    )
 
     return HttpResponse(json.dumps(data), content_type="application/json")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='django-s3direct',
-    version='0.4.1',
+    version='0.4.2',
     description='Add direct uploads to S3 functionality with a progress bar to file input fields.',
     long_description=readme,
     author="Bradley Griffiths",


### PR DESCRIPTION
Add support for [s3 server-side encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/SSEUsingRESTAPI.html). This allows PUT/POST on buckets with policies that require it, such as

```
{
    "Sid": "DenyIncorrectEncryptionHeader",
    "Effect": "Deny",
    "Principal": "*",
    "Action": "s3:PutObject",
    "Resource": "arn:aws:s3:::bucket/*",
    "Condition": {
        "StringNotEquals": {
            "s3:x-amz-server-side-encryption": "AES256"
        }
    }
}
```