### PR TITLE
Add handlers for each s3direct field in a dynamically generated form.

### DIFF
--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -177,8 +177,10 @@
 
     document.addEventListener('DOMNodeInserted', function(e){
         if(e.target.tagName) {
-            var el = e.target.querySelector('.s3direct')
-            if(el) addHandlers(el)
+            var el = e.target.querySelectorAll('.s3direct');
+	    el.forEach(function (element, index, array) {
+		addHandlers(element);
+	    });
         }
     })
 


### PR DESCRIPTION
Currently, dynamically creating a single form with multiple s3direct fields only add handlers to the first field. This change ensures that all fields in the form work correctly.