### PR TITLE
Widget render unicode bug

### DIFF
--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import reverse
 class S3DirectWidget(widgets.TextInput):
 
     default_html = (
-        '<div class="s3direct" data-policy-url="{policy_url}">'
+        u'<div class="s3direct" data-policy-url="{policy_url}">'
         '  <a class="file-link" target="_blank" href="{file_url}">{file_name}</a>'
         '  <a class="file-remove" href="#remove">Remove</a>'
         '  <input class="file-url" type="hidden" value="{file_url}" id="{element_id}" name="{name}" />'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='django-s3direct',
-    version='0.4.2',
+    version='0.4.3',
     description='Add direct uploads to S3 functionality with a progress bar to file input fields.',
     long_description=readme,
     author="Bradley Griffiths",


### PR DESCRIPTION
If a filename containing unicode is uploaded using the widget, the widget will fail to re-render (e.g. in admin change view or when the form fails contains errors). Ensuring the widget html is treated as a unicode string fixes it.