### PR TITLE
use [].forEach on NodeList instance

### DIFF
--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -178,7 +178,7 @@
     document.addEventListener('DOMNodeInserted', function(e){
         if(e.target.tagName) {
             var el = e.target.querySelectorAll('.s3direct');
-	    el.forEach(function (element, index, array) {
+            [].forEach.call(el, function (element, index, array) {
 		addHandlers(element);
 	    });
         }


### PR DESCRIPTION
querySelectorAll returns a NodeList which doesn't have a `forEach` method but `[].forEach` works fine with NodeLists. 

Before thins change, I see

> eError: el.forEach is not a function 

https://css-tricks.com/snippets/javascript/loop-queryselectorall-matches/
