### PR TITLE
Update settings and imports for Django 1.10.3

### DIFF
--- a/example/cat/urls.py
+++ b/example/cat/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import MyView
 

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = ')nw@1z2xt-dy2f$1mfpzyuohxv-tmu4+5-q55)*(e6obam-p=4'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [u'0.0.0.0']
 
 
 # Application definition

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 


### PR DESCRIPTION
The install script grabs Django 1.10, which deprecated `django.conf.urls.patterns()`. Happily, this project wasn't using that function anyway.

Additionally, Django 1.10.3 [changed the behavior of ALLOWED_HOSTS](https://docs.djangoproject.com/en/1.10/ref/settings/#allowed-hosts), which is now always checked, even if `DEBUG=TRUE`. This commit adds the suggested default server, `0.0.0.0`, to ALLOWED_HOSTS.