### PR TITLE
Fix CSRF token fetch

### DIFF
--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -131,7 +131,24 @@
             dest     = el.querySelector('.file-dest').value,
             url      = el.getAttribute('data-policy-url'),
             form     = new FormData(),
-            headers  = {'X-CSRFToken': getCookie('csrftoken')}
+            headers  = {};
+
+        var csrfTokenField = document.querySelector("input[name='csrfmiddlewaretoken']");
+        var csrfToken;
+        
+        if (csrfTokenField) {
+            csrfToken = csrfTokenField.value;
+        } else {
+            csrfToken = false;
+        }
+        if (!csrfToken) {
+            csrfToken = getCookie('csrftoken');
+            if (!csrfToken) {
+                console.error("CSRF token can't be determined!")
+            }
+        }
+        
+        headers['X-CSRFToken'] = csrfToken;
 
         form.append('type', file.type)
         form.append('name', file.name)


### PR DESCRIPTION
cookie doesn't work if static file located at CDN with different domain (S3, for example), so in this case code tries to fetch `csrfmiddlewaretoken` field value. If it fails then cookie is used. If cookie is empty then no one can save us.