### PR TITLE
Namespaced AWS access keys and bucket name settings

### DIFF
--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -63,9 +63,21 @@ def get_s3direct_destinations():
 def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
                        content_disposition=None, content_length_range=None,
                        server_side_encryption=None):
-    access_key = settings.AWS_ACCESS_KEY_ID
-    secret_access_key = settings.AWS_SECRET_ACCESS_KEY
-    bucket = bucket or settings.AWS_STORAGE_BUCKET_NAME
+    access_key = getattr(
+        settings,
+        'S3DIRECT_AWS_ACCESS_KEY_ID',
+        None
+    ) or getattr(settings, 'AWS_ACCESS_KEY_ID')
+    secret_access_key = getattr(
+        settings,
+        'S3DIRECT_AWS_SECRET_ACCESS_KEY',
+        None
+    ) or getattr(settings, 'AWS_SECRET_ACCESS_KEY')
+    bucket = bucket or getattr(
+        settings,
+        'S3DIRECT_AWS_STORAGE_BUCKET_NAME',
+        None
+    ) or getattr(settings, 'AWS_STORAGE_BUCKET_NAME')
     region = getattr(settings, 'S3DIRECT_REGION', None)
     endpoint = REGIONS.get(region, 's3.amazonaws.com')
 


### PR DESCRIPTION
Backwards-compatible.
If user provided S3DIRECT_AWS_ACCESS_KEY_ID use it, else try to use AWS_ACCESS_KEY_ID
Same for S3DIRECT_AWS_SECRET_ACCESS_KEY and S3DIRECT_AWS_STORAGE_BUCKET_NAME.

So it's possible to distinct IAM roles/permissions for public requests and for private from web application (work with SQS, for example)