### PR TITLE
Return decoded URL

### DIFF
--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -35,7 +35,7 @@
     var parseURL = function(text) {
         var xml = new DOMParser().parseFromString(text, 'text/xml'),
             tag = xml.getElementsByTagName('Location')[0],
-            url = tag.childNodes[0].nodeValue
+            url = decodeURIComponent(tag.childNodes[0].nodeValue)
 
         return url;
     }


### PR DESCRIPTION
in case, key = test_key, file_name= file.png
s3 returns "https://s3.com/bucket/key%2Ffilen.png" not "https://s3.com/bucket/key/filen.png"
it works but it looks ugly to me and have to decode it at server before save it.

According the code, file name decoded before showing to user, so I decode URL too.

