### PR TITLE
Use instance profile if AWS access credentials are not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ TEMPLATES = [{
     ...
 }]
 
-# AWS keys
-AWS_SECRET_ACCESS_KEY = ''
+# AWS 
+
+# If these are not defined, the EC2 instance profile is used.
+# This requires you to add boto3 or botocore to your project dependencies.
 AWS_ACCESS_KEY_ID = ''
+AWS_SECRET_ACCESS_KEY = ''
+
 AWS_STORAGE_BUCKET_NAME = ''
 
 # The region of your bucket, more info:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,49 @@ Install with Pip:
 
 ```pip install django-s3direct```
 
-## S3 Setup
+## AWS Setup
+
+### Access Credentials
+
+You have two options of providing access to AWS resources:
+
+1. Add credentials of an IAM user to your Django settings (see below)
+2. Use the EC2 instance profile and its attached IAM role
+
+Whether you are using an IAM user or a role, there needs to be an IAM policy
+in effect that grants permission to upload to S3: 
+
+```json
+"Statement": [
+  {
+    "Effect": "Allow",
+    "Action": ["s3:PutObject", "s3:PutObjectAcl"],
+    "Resource": "arn:aws:s3:::your-bucket-name/*"
+  }
+]
+```
+
+If the instance profile is to be used, the IAM role needs to have a 
+Trust Relationship configuration applied:
+
+```json
+"Statement": [
+	{
+		"Effect": "Allow",
+		"Principal": {
+			"Service": "ec2.amazonaws.com"
+		},
+		"Action": "sts:AssumeRole"
+	}
+]
+```
+
+Note that in order to use the EC2 instance profile, django-s3direct needs 
+to query the EC2 instance metadata using utility functions from the
+[botocore] [] package. You already have `botocore` installed if `boto3`
+is a dependency of your project.
+
+### S3 CORS
 
 Setup a CORS policy on your S3 bucket.
 
@@ -50,8 +92,9 @@ TEMPLATES = [{
 
 # AWS 
 
-# If these are not defined, the EC2 instance profile is used.
-# This requires you to add boto3 or botocore to your project dependencies.
+# If these are not defined, the EC2 instance profile and IAM role are used.
+# This requires you to add boto3 (or botocore, which is a dependency of boto3) 
+# to your project dependencies.
 AWS_ACCESS_KEY_ID = ''
 AWS_SECRET_ACCESS_KEY = ''
 
@@ -173,3 +216,5 @@ $ python manage.py runserver 0.0.0.0:5000
 ```
 
 Visit ```http://localhost:5000/admin``` to view the admin widget and ```http://localhost:5000/form``` to view the custom form widget.
+
+[botocore]: https://github.com/boto/botocore

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -104,8 +104,11 @@ USE_TZ = True
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
 
+# If AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not defined,
+# django-s3direct will attempt to use the EC2 instance profile instead.
 AWS_ACCESS_KEY_ID = ''
 AWS_SECRET_ACCESS_KEY = ''
+
 AWS_STORAGE_BUCKET_NAME = ''
 S3DIRECT_REGION = ''
 

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -104,7 +104,7 @@ class WidgetTestCase(TestCase):
                 u'type': u'image/jpeg'}
         response = self.client.post(reverse('s3direct'), data)
         response_dict = json.loads(response.content.decode())
-        self.assertTrue(u'x-amz-credential' in response_dict)
+        self.assertTrue(u'x-amz-signature' in response_dict)
         self.assertTrue(u'x-amz-credential' in response_dict)
         self.assertTrue(u'policy' in response_dict)
         changed = FOO_RESPONSE.copy()

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -47,12 +47,10 @@ def get_s3direct_destinations():
 
     return converted_destinations
 
-
 def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
                        content_disposition=None, content_length_range=None,
-                       server_side_encryption=None):
-    access_key = settings.AWS_ACCESS_KEY_ID
-    secret_access_key = settings.AWS_SECRET_ACCESS_KEY
+                       server_side_encryption=None, access_key=None, secret_access_key=None, token=None):
+
     bucket = bucket or settings.AWS_STORAGE_BUCKET_NAME
     region = getattr(settings, 'S3DIRECT_REGION', None)
     if not region or region == 'us-east-1':
@@ -80,6 +78,9 @@ def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
                 {"content-type": content_type},
             ]
         }
+
+    if token:
+        policy_dict["conditions"].append({"x-amz-security-token": token})
 
     if cache_control:
         policy_dict['conditions'].append({'Cache-Control': cache_control})
@@ -143,6 +144,9 @@ def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
         "acl": acl,
         "content-type": content_type
     }
+
+    if token:
+        return_dict['x-amz-security-token'] = token
 
     if cache_control:
         return_dict['Cache-Control'] = cache_control

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -56,7 +56,7 @@ def get_upload_params(request):
     secret_access_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
     token = None
 
-    if not all([access_key, secret_access_key]):
+    if access_key is None or secret_access_key is None:
         # Get credentials from instance profile if not defined in settings --
         # this avoids the need to put access credentials in the settings.py file.
         # Assumes we're running on EC2.

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -2,6 +2,7 @@ import json
 
 from django.http import HttpResponse
 from django.views.decorators.http import require_POST
+from django.conf import settings
 
 from .utils import create_upload_data, get_s3direct_destinations
 
@@ -51,9 +52,34 @@ def get_upload_params(request):
         # https://aws.amazon.com/articles/1434#aws-table
         key = '%s/${filename}' % key
 
+    access_key = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
+    secret_access_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
+    token = None
+
+    if not all([access_key, secret_access_key]):
+        # Get credentials from instance profile if not defined in settings --
+        # this avoids the need to put access credentials in the settings.py file.
+        # Assumes we're running on EC2.
+
+        try:
+            from botocore.credentials import InstanceMetadataProvider, InstanceMetadataFetcher
+        except ImportError:
+            pass
+
+        if all([InstanceMetadataProvider, InstanceMetadataFetcher]):
+            provider = InstanceMetadataProvider(iam_role_fetcher=InstanceMetadataFetcher(timeout=1000, num_attempts=2))
+            creds = provider.load()
+            access_key = creds.access_key
+            secret_access_key = creds.secret_key
+            token = creds.token
+        else:
+            data = json.dumps({'error': 'Failed to access EC2 instance metadata due to missing dependency.'})
+            return HttpResponse(data, content_type="application/json", status=500)
+
+
     data = create_upload_data(
         content_type, key, acl, bucket, cache_control, content_disposition,
-        content_length_range, server_side_encryption
+        content_length_range, server_side_encryption, access_key, secret_access_key, token
     )
 
     return HttpResponse(json.dumps(data), content_type="application/json")

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -64,7 +64,8 @@ def get_upload_params(request):
         try:
             from botocore.credentials import InstanceMetadataProvider, InstanceMetadataFetcher
         except ImportError:
-            pass
+            InstanceMetadataProvider = None
+            InstanceMetadataFetcher = None
 
         if all([InstanceMetadataProvider, InstanceMetadataFetcher]):
             provider = InstanceMetadataProvider(iam_role_fetcher=InstanceMetadataFetcher(timeout=1000, num_attempts=2))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='django-s3direct',
-    version='0.4.8',
+    version='0.4.8-artory',
     description=('Add direct uploads to S3 functionality with a progress bar'
                  ' to file input fields.'),
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='django-s3direct',
-    version='0.4.8-artory',
+    version='0.4.9',
     description=('Add direct uploads to S3 functionality with a progress bar'
                  ' to file input fields.'),
     long_description=readme,


### PR DESCRIPTION
Using the EC2 instance profile with attached IAM role for controlling access to AWS resources is common practice. This avoids the need to add access credentials to `settings.py` when the application is deployed to EC2.

This PR adds functionality to fall back on the EC2 instance profile in case access credentials are not found in the Django settings. In this case, dependencies from the `botocore` package are lazily loaded, so it will only work if that package is installed. The README mentions this.