### PR TITLE
Update compatibility to Django 1.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ env:
   - DJANGO=1.9
   - DJANGO=1.10
 install:
-  - pip install -q Django==$DJANGO
+  - pip install -q Django~=$DJANGO.0
 script:
   - python runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: python
 python:
   - 2.7
   - 3.4
+  - 3.5
+  - 3.6
 env:
-  - DJANGO=1.5
-  - DJANGO=1.6
-  - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
+  - DJANGO=1.11
 install:
   - pip install -q Django~=$DJANGO.0
 script:

--- a/runtests.py
+++ b/runtests.py
@@ -28,8 +28,13 @@ settings.configure(
     TEMPLATES=[
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'APP_DIRS': True
-        }
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    "django.contrib.auth.context_processors.auth",
+                ]
+            }
+        },
     ],
     AWS_ACCESS_KEY_ID=environ.get('AWS_ACCESS_KEY_ID', ''),
     AWS_SECRET_ACCESS_KEY=environ.get('AWS_SECRET_ACCESS_KEY', ''),

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -25,7 +25,7 @@ class S3DirectWidget(widgets.TextInput):
         self.dest = kwargs.pop('dest', None)
         super(S3DirectWidget, self).__init__(*args, **kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, **kwargs):
         if value:
             file_name = os.path.basename(urlunquote_plus(value))
         else:
@@ -34,12 +34,12 @@ class S3DirectWidget(widgets.TextInput):
         tpl = os.path.join('s3direct', 's3direct-widget.tpl')
         output = render_to_string(tpl, {
             'policy_url': reverse('s3direct'),
-            'element_id': self.build_attrs(attrs).get('id', ''),
+            'element_id': self.build_attrs(attrs).get('id', '') if attrs else '',
             'file_name': file_name,
             'dest': self.dest,
             'file_url': value or '',
             'name': name,
-            'style': self.build_attrs(attrs).get('style', '')
+            'style': self.build_attrs(attrs).get('style', '') if attrs else '',
         })
 
         return mark_safe(output)

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/bradleyg/django-s3direct',
     packages=['s3direct'],
     include_package_data=True,
-    install_requires=['django>=1.8,~=1.11'],
+    install_requires=['django>=1.8,~=1.11.0'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/bradleyg/django-s3direct',
     packages=['s3direct'],
     include_package_data=True,
-    install_requires=['django>=1.8,~=1.11.0'],
+    install_requires=['django>=1.8,~=1.11'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/bradleyg/django-s3direct',
     packages=['s3direct'],
     include_package_data=True,
-    install_requires=['django>=1.6.2'],
+    install_requires=['django>=1.8,<1.11'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/bradleyg/django-s3direct',
     packages=['s3direct'],
     include_package_data=True,
-    install_requires=['django>=1.8,<1.11'],
+    install_requires=['django>=1.8,~=1.11'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This fixes issue #109, where tests fail under combinations of Python 3.5+ and Django <1.8 by dropping compatibility with earlier versions of Django.

- Specifies Python 3.5 and 3.6 compatibility.
    - Drops Django <1.8 compatibility.
- Fixes test setup for Django 1.8+ compatibility.
- Adds Django 1.11 compatibility
    - handles [internal Django API change in 1.11](https://code.djangoproject.com/ticket/28095)