### PR TITLE
Take example app AWS/S3 credentials from environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You have two options of providing access to AWS resources:
 2. Use the EC2 instance profile and its attached IAM role
 
 Whether you are using an IAM user or a role, there needs to be an IAM policy
-in effect that grants permission to upload to S3: 
+in effect that grants permission to upload to S3:
 
 ```json
 "Statement": [
@@ -38,7 +38,7 @@ in effect that grants permission to upload to S3:
 ]
 ```
 
-If the instance profile is to be used, the IAM role needs to have a 
+If the instance profile is to be used, the IAM role needs to have a
 Trust Relationship configuration applied:
 
 ```json
@@ -53,7 +53,7 @@ Trust Relationship configuration applied:
 ]
 ```
 
-Note that in order to use the EC2 instance profile, django-s3direct needs 
+Note that in order to use the EC2 instance profile, django-s3direct needs
 to query the EC2 instance metadata using utility functions from the
 [botocore] [] package. You already have `botocore` installed if `boto3`
 is a dependency of your project.
@@ -91,10 +91,10 @@ TEMPLATES = [{
     ...
 }]
 
-# AWS 
+# AWS
 
 # If these are not defined, the EC2 instance profile and IAM role are used.
-# This requires you to add boto3 (or botocore, which is a dependency of boto3) 
+# This requires you to add boto3 (or botocore, which is a dependency of boto3)
 # to your project dependencies.
 AWS_ACCESS_KEY_ID = ''
 AWS_SECRET_ACCESS_KEY = ''
@@ -201,15 +201,22 @@ class MyView(FormView):
 </html>
 ```
 
+
 ## Examples
+
 Examples of both approaches can be found in the examples folder. To run them:
+
 ```shell
 $ git clone git@github.com:bradleyg/django-s3direct.git
 $ cd django-s3direct
 $ python setup.py install
 $ cd example
 
-# Add your AWS keys to settings.py
+# Add your AWS keys to your environment
+export AWS_ACCESS_KEY_ID='…'
+export AWS_SECRET_ACCESS_KEY='…'
+export AWS_STORAGE_BUCKET_NAME='…'
+export S3DIRECT_REGION='…'    # e.g. 'eu-west-1'
 
 $ python manage.py migrate
 $ python manage.py createsuperuser

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -106,11 +106,11 @@ STATIC_URL = '/static/'
 
 # If AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not defined,
 # django-s3direct will attempt to use the EC2 instance profile instead.
-AWS_ACCESS_KEY_ID = ''
-AWS_SECRET_ACCESS_KEY = ''
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
 
-AWS_STORAGE_BUCKET_NAME = ''
-S3DIRECT_REGION = ''
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', 'test-bucket')
+S3DIRECT_REGION = os.environ.get('S3DIRECT_REGION', 'us-east-1')
 
 
 def create_filename(filename):

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -1,6 +1,7 @@
 import json
 from base64 import b64decode
 
+from django.conf import settings
 from django.test.utils import override_settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse, resolve
@@ -25,7 +26,7 @@ HTML_OUTPUT = (
 
 FOO_RESPONSE = {
     u'x-amz-algorithm': u'AWS4-HMAC-SHA256',
-    u'form_action': u'https://s3.amazonaws.com/test-bucket',
+    u'form_action': u'https://s3.amazonaws.com/{}'.format(settings.AWS_STORAGE_BUCKET_NAME),
     u'success_action_status': 201,
     u'acl': u'public-read',
     u'key': u'uploads/imgs/${filename}',


### PR DESCRIPTION
This means you can run the example app just the same as running
tests, by setting

- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_STORAGE_BUCKET_NAME`
- `S3DIRECT_REGION`

in your environment variables, rather than in the example app's
`settings.py`, where you risk committing credentials while working
with the example app.