### PR TITLE
Multipart-upload using EvaporateJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ example/db.sqlite3
 example/example/settings-test.py
 /build
 .idea
+/s3direct/static/s3direct/js/bundled.js

--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ in effect that grants permission to upload to S3:
 "Statement": [
   {
     "Effect": "Allow",
-    "Action": ["s3:PutObject", "s3:PutObjectAcl"],
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload"
+    ],
     "Resource": "arn:aws:s3:::your-bucket-name/*"
   }
 ]
@@ -66,9 +72,12 @@ Setup a CORS policy on your S3 bucket.
 <CORSConfiguration>
     <CORSRule>
         <AllowedOrigin>http://yourdomain.com:8080</AllowedOrigin>
-        <AllowedMethod>POST</AllowedMethod>
+        <AllowedMethod>GET</AllowedMethod>
+        <AllowedMethod>HEAD</AllowedMethod>
         <AllowedMethod>PUT</AllowedMethod>
+        <AllowedMethod>POST</AllowedMethod>
         <MaxAgeSeconds>3000</MaxAgeSeconds>
+        <ExposeHeader>ETag</ExposeHeader>
         <AllowedHeader>*</AllowedHeader>
     </CORSRule>
 </CORSConfiguration>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ Install with Pip:
 
 ```pip install django-s3direct```
 
+### Backwards-Compatiblity
+
+With 1.0.0 supporting multipart-upload, most of the internals have been
+changed, a new endpoint has been added, and support has been dropped for
+old style positional settings. There are also new requirements to allow
+`GET` and `HEAD` cross-origin requests to S3, as well as
+the `ETAG` header. Django compatibility has been raised to `>=1.8`.
+
+If you used any of these features or relied on the previous behaviour,
+it's recommended that you pin `django-s3direct` to `<1.0` until you
+can test the new version in your project:
+
+```sh
+pip install 'django-s3direct <1.0'
+```
+
+
 ## AWS Setup
 
 ### Access Credentials

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -106,11 +106,11 @@ STATIC_URL = '/static/'
 
 # If AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not defined,
 # django-s3direct will attempt to use the EC2 instance profile instead.
-AWS_ACCESS_KEY_ID = ''
-AWS_SECRET_ACCESS_KEY = ''
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
 
-AWS_STORAGE_BUCKET_NAME = ''
-S3DIRECT_REGION = ''
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', 'test-bucket')
+S3DIRECT_REGION = os.environ.get('S3DIRECT_REGION', 'us-east-1')
 
 
 def create_filename(filename):

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "directories": {
     "example": "example"
   },
-  "dependencies": {},
+  "dependencies": {
+    "js-cookie": "^2.1.4"
+  },
   "devDependencies": {
     "browserify": "^14.3.0",
     "watchify": "^3.9.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "example": "example"
   },
   "dependencies": {
-    "js-cookie": "^2.1.4"
+    "js-cookie": "^2.1.4",
+    "evaporate": "^2.1.1",
+    "sha.js": "^2.4.8",
+    "spark-md5": "^3.0.0"
   },
   "devDependencies": {
     "browserify": "^14.3.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "django-s3direct",
+  "version": "0.4.10",
+  "description": "Add direct uploads to S3 functionality with a progress bar to file input fields.",
+  "directories": {
+    "example": "example"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "browserify": "^14.3.0",
+    "watchify": "^3.9.0"
+  },
+  "scripts": {
+    "test": "python runtests.py",
+    "build": "browserify s3direct/static/s3direct/js/scripts.js -o s3direct/static/s3direct/js/bundled.js",
+    "watch": "watchify s3direct/static/s3direct/js/scripts.js -o s3direct/static/s3direct/js/bundled.js --debug --verbose"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bradleyg/django-s3direct.git"
+  },
+  "keywords": [
+    "django",
+    "S3",
+    "file",
+    "upload"
+  ],
+  "author": "Bradley Griffiths",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bradleyg/django-s3direct/issues"
+  },
+  "homepage": "https://github.com/bradleyg/django-s3direct#readme"
+}

--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -1,12 +1,15 @@
-var Cookies = require('js-cookie');
+const Cookies = require('js-cookie');
+const createHash = require('sha.js')
+const Evaporate = require('evaporate');
+const SparkMD5 = require('spark-md5');
 
 
 (function(){
 
     "use strict"
 
-    var request = function(method, url, data, headers, el, showProgress, cb) {
-        var req = new XMLHttpRequest()
+    var request = function(method, url, data, headers, el, cb) {
+        let req = new XMLHttpRequest()
         req.open(method, url, true)
 
         Object.keys(headers).forEach(function(key){
@@ -22,19 +25,7 @@ var Cookies = require('js-cookie');
             error(el, 'Sorry, failed to upload file.')
         }
 
-        req.upload.onprogress = function(data) {
-            progressBar(el, data, showProgress)
-        }
-
         req.send(data)
-    }
-
-    var parseURL = function(text) {
-        var xml = new DOMParser().parseFromString(text, 'text/xml'),
-            tag = xml.getElementsByTagName('Location')[0],
-            url = decodeURIComponent(tag.childNodes[0].nodeValue)
-
-        return url;
     }
 
     var parseNameFromUrl = function(url) {
@@ -48,14 +39,10 @@ var Cookies = require('js-cookie');
         return data
     }
 
-    var progressBar = function(el, data, showProgress) {
-        if(data.lengthComputable === false || showProgress === false) return
-
-        var pcnt = Math.round(data.loaded * 100 / data.total),
-            bar  = el.querySelector('.bar')
-
-        bar.style.width = pcnt + '%'
-    }
+    var updateProgressBar = function(element, progressRatio) {
+        var bar = element.querySelector('.bar');
+        bar.style.width = Math.round(progressRatio * 100) + '%';
+    };
 
     var error = function(el, msg) {
         el.className = 's3direct form-active'
@@ -63,19 +50,8 @@ var Cookies = require('js-cookie');
         alert(msg)
     }
 
-    var update = function(el, xml) {
-        var link = el.querySelector('.file-link'),
-            url  = el.querySelector('.file-url')
+    var concurrentUploads = 0;
 
-        url.value = parseURL(xml)
-        link.setAttribute('href', url.value)
-        link.innerHTML = parseNameFromUrl(url.value).split('/').pop();
-
-        el.className = 's3direct link-active'
-        el.querySelector('.bar').style.width = '0%'
-    }
-
-    var concurrentUploads = 0
     var disableSubmit = function(status) {
         var submitRow = document.querySelector('.submit-row')
         if( ! submitRow) return
@@ -90,63 +66,137 @@ var Cookies = require('js-cookie');
         })
     }
 
-    var upload = function(file, data, el) {
-        var form = new FormData()
+    const beginUpload = function (element) {
+        disableSubmit(true);
+        element.className = 's3direct progress-active'
+    };
 
-        disableSubmit(true)
+    const finishUpload = function (element, awsBucketUrl, objectKey) {
+        const link = element.querySelector('.file-link');
+        const url = element.querySelector('.file-url');
+        url.value = awsBucketUrl + '/' + objectKey;
+        link.setAttribute('href', url.value);
+        link.innerHTML = parseNameFromUrl(url.value).split('/').pop();
 
-        if (data === null) return error(el, 'Sorry, could not get upload URL.')
+        element.className = 's3direct link-active';
+        element.querySelector('.bar').style.width = '0%';
+        disableSubmit(false);
+    };
 
-        el.className = 's3direct progress-active'
-        var url  = data['form_action']
-        delete data['form_action']
+    const computeMd5 = function (data) {
+        return btoa(SparkMD5.ArrayBuffer.hash(data, true));
+    };
 
-        Object.keys(data).forEach(function(key){
-            form.append(key, data[key])
-        })
-        form.append('file', file)
+    const computeSha256 = function (data) {
+        return createHash('sha256').update(data, 'utf-8').digest('hex');
+    };
 
-        request('POST', url, form, {}, el, true, function(status, xml){
-            disableSubmit(false)
-            if(status !== 201) {
-                if (xml.indexOf('<MinSizeAllowed>') > -1) {
-                    return error(el, 'Sorry, the file is too small to be uploaded.')
-                }
-                else if (xml.indexOf('<MaxSizeAllowed>') > -1) {
-                    return error(el, 'Sorry, the file is too large to be uploaded.')
-                }
+    const initiateMultipartUpload = function (element, signingUrl, objectKey, awsKey, awsRegion, awsBucket, awsBucketUrl, cacheControl, contentDisposition, acl, serverSideEncryption, file) {
+        // Enclosed so we can propagate errors to the correct `element` in case of failure.
+        const getAwsV4Signature = function (signParams, signHeaders, stringToSign, signatureDateTime, canonicalRequest) {
+            return new Promise(function (resolve, reject) {
+                const form = new FormData();
+                form.append('to_sign', stringToSign);
+                form.append('datetime', signatureDateTime);
+                const headers = {'X-CSRFToken': Cookies.get('csrftoken')};
+                request('POST', signingUrl, form, headers, element, function (status, response) {
+                    switch (status) {
+                        case 200:
+                            resolve(response);
+                            break;
+                        default:
+                            error(element, 'Could not generate AWS v4 signature.')
+                            reject();
+                            break;
+                    }
+                });
+            })
+        };
 
-                return error(el, 'Sorry, failed to upload file.')
+        const generateAmazonHeaders = function (acl, serverSideEncryption) {
+            // Either of these may be null, so don't add them unless they exist:
+            let headers = {}
+            if (acl) headers['x-amz-acl'] = acl;
+            if (serverSideEncryption) headers['x-amz-server-side-encryption'] = serverSideEncryption;
+            return headers;
+        };
+
+        Evaporate.create(
+            {
+                //signerUrl: signingUrl,
+                customAuthMethod: getAwsV4Signature,
+                aws_key: awsKey,
+                bucket: awsBucket,
+                awsRegion: awsRegion,
+                computeContentMd5: true,
+                cryptoMd5Method: computeMd5,
+                cryptoHexEncodedHash256: computeSha256,
+                partSize: 20 * 1024 * 1024,
+                logging: true,
+                debug: true,
             }
-            update(el, xml)
-        })
-    }
+        ).then(function (evaporate) {
+            beginUpload(element);
+            evaporate.add({
+                name: objectKey,
+                file: file,
+                contentType: file.type,
+                xAmzHeadersAtInitiate: generateAmazonHeaders(acl, serverSideEncryption),
+                notSignedHeadersAtInitiate: {'Cache-Control': cacheControl, 'Content-Disposition': contentDisposition},
+                progress: function (progressRatio, stats) { updateProgressBar(element, progressRatio); },
+            }).then(
+                function (awsS3ObjectKey) {
+                    console.log('Successfully uploaded to:', awsS3ObjectKey);
+                    finishUpload(element, awsBucketUrl, awsS3ObjectKey);
+                },
+                function (reason) {
+                    console.error('Failed to upload because:', reason);
+                    return error(element, reason)
+                }
+            )
+        });
+    };
 
-    var getUploadURL = function(e) {
-        var el       = e.target.parentElement,
-            file     = el.querySelector('.file-input').files[0],
-            dest     = el.querySelector('.file-dest').value,
-            url      = el.getAttribute('data-policy-url'),
-            form     = new FormData(),
-            headers  = {'X-CSRFToken': Cookies.get('csrftoken')};
+    var checkFileAndInitiateUpload = function(event) {
+        console.log('Checking file and initiating upload…')
+        var element             = event.target.parentElement,
+            file                = element.querySelector('.file-input').files[0],
+            dest                = element.querySelector('.file-dest').value,
+            destinationCheckUrl = element.getAttribute('data-policy-url'),
+            signerUrl           = element.getAttribute('data-signing-url'),
+            form                = new FormData(),
+            headers             = {'X-CSRFToken': Cookies.get('csrftoken')};
 
-        form.append('type', file.type)
-        form.append('name', file.name)
         form.append('dest', dest)
-
-        request('POST', url, form, headers, el, false, function(status, json){
-            var data = parseJson(json)
-
+        form.append('name', file.name)
+        form.append('type', file.type)
+        form.append('size', file.size)
+        request('POST', destinationCheckUrl, form, headers, element, function(status, response) {
+            const uploadParameters = parseJson(response)
             switch(status) {
                 case 200:
-                    upload(file, data, el)
-                    break
+                    initiateMultipartUpload(
+                        element,
+                        signerUrl,
+                        uploadParameters.object_key,
+                        uploadParameters.access_key_id,
+                        uploadParameters.region,
+                        uploadParameters.bucket,
+                        uploadParameters.bucket_url,
+                        uploadParameters.cache_control,
+                        uploadParameters.content_disposition,
+                        uploadParameters.acl,
+                        uploadParameters.server_side_encryption,
+                        file
+                    );
+                    break;
                 case 400:
                 case 403:
-                    error(el, data.error)
+                case 500:
+                    error(element, uploadParameters.error)
                     break;
                 default:
-                    error(el, 'Sorry, could not get upload URL.')
+                    error(element, 'Sorry, could not get upload URL.')
             }
         })
     }
@@ -161,6 +211,7 @@ var Cookies = require('js-cookie');
     }
 
     var addHandlers = function(el) {
+        console.log('Adding django-s3direct handlers…');
         var url    = el.querySelector('.file-url'),
             input  = el.querySelector('.file-input'),
             remove = el.querySelector('.file-remove'),
@@ -169,7 +220,7 @@ var Cookies = require('js-cookie');
         el.className = 's3direct ' + status + '-active'
 
         remove.addEventListener('click', removeUpload, false)
-        input.addEventListener('change', getUploadURL, false)
+        input.addEventListener('change', checkFileAndInitiateUpload, false)
     }
 
     document.addEventListener('DOMContentLoaded', function(e) {

--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -138,6 +138,8 @@ const SparkMD5 = require('spark-md5');
                 partSize: 20 * 1024 * 1024,
                 logging: true,
                 debug: true,
+                allowS3ExistenceOptimization: true,
+                s3FileCacheHoursAgo: 12,
             }
         ).then(function (evaporate) {
             beginUpload(element);

--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -1,12 +1,9 @@
+var Cookies = require('js-cookie');
+
+
 (function(){
 
     "use strict"
-
-    var getCookie = function(name) {
-        var value = '; ' + document.cookie,
-            parts = value.split('; ' + name + '=')
-        if (parts.length == 2) return parts.pop().split(';').shift()
-    }
 
     var request = function(method, url, data, headers, el, showProgress, cb) {
         var req = new XMLHttpRequest()
@@ -131,7 +128,7 @@
             dest     = el.querySelector('.file-dest').value,
             url      = el.getAttribute('data-policy-url'),
             form     = new FormData(),
-            headers  = {'X-CSRFToken': getCookie('csrftoken')}
+            headers  = {'X-CSRFToken': Cookies.get('csrftoken')};
 
         form.append('type', file.type)
         form.append('name', file.name)

--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -8,55 +8,59 @@ const SparkMD5 = require('spark-md5');
 
     "use strict"
 
-    var request = function(method, url, data, headers, el, cb) {
+    const request = function (method, url, data, headers, el, cb) {
         let req = new XMLHttpRequest()
         req.open(method, url, true)
 
-        Object.keys(headers).forEach(function(key){
+        Object.keys(headers).forEach(function (key) {
             req.setRequestHeader(key, headers[key])
-        })
+        });
 
-        req.onload = function() {
+        req.onload = function () {
             cb(req.status, req.responseText)
-        }
+        };
 
-        req.onerror = req.onabort = function() {
+        req.onerror = req.onabort = function () {
             disableSubmit(false)
             error(el, 'Sorry, failed to upload file.')
-        }
+        };
 
         req.send(data)
-    }
+    };
 
-    var parseNameFromUrl = function(url) {
+    const parseNameFromUrl = function (url) {
         return decodeURIComponent((url + '').replace(/\+/g, '%20'));
-    }
+    };
 
-    var parseJson = function(json) {
-        var data
-        try {data = JSON.parse(json)}
-        catch(e){ data = null }
+    const parseJson = function (json) {
+        let data;
+        try {
+            data = JSON.parse(json);
+        }
+        catch (e) {
+            data = null;
+        }
         return data
-    }
+    };
 
-    var updateProgressBar = function(element, progressRatio) {
-        var bar = element.querySelector('.bar');
+    const updateProgressBar = function (element, progressRatio) {
+        const bar = element.querySelector('.bar');
         bar.style.width = Math.round(progressRatio * 100) + '%';
     };
 
-    var error = function(el, msg) {
+    const error = function(el, msg) {
         el.className = 's3direct form-active'
         el.querySelector('.file-input').value = ''
         alert(msg)
-    }
+    };
 
-    var concurrentUploads = 0;
+    let concurrentUploads = 0;
 
-    var disableSubmit = function(status) {
-        var submitRow = document.querySelector('.submit-row')
+    const disableSubmit = function(status) {
+        const submitRow = document.querySelector('.submit-row')
         if( ! submitRow) return
 
-        var buttons = submitRow.querySelectorAll('input[type=submit],button[type=submit]')
+        const buttons = submitRow.querySelectorAll('input[type=submit],button[type=submit]');
 
         if (status === true) concurrentUploads++
         else concurrentUploads--
@@ -157,15 +161,15 @@ const SparkMD5 = require('spark-md5');
         });
     };
 
-    var checkFileAndInitiateUpload = function(event) {
+    const checkFileAndInitiateUpload = function(event) {
         console.log('Checking file and initiating upload…')
-        var element             = event.target.parentElement,
-            file                = element.querySelector('.file-input').files[0],
-            dest                = element.querySelector('.file-dest').value,
-            destinationCheckUrl = element.getAttribute('data-policy-url'),
-            signerUrl           = element.getAttribute('data-signing-url'),
-            form                = new FormData(),
-            headers             = {'X-CSRFToken': Cookies.get('csrftoken')};
+        const element             = event.target.parentElement,
+              file                = element.querySelector('.file-input').files[0],
+              dest                = element.querySelector('.file-dest').value,
+              destinationCheckUrl = element.getAttribute('data-policy-url'),
+              signerUrl           = element.getAttribute('data-signing-url'),
+              form                = new FormData(),
+              headers             = {'X-CSRFToken': Cookies.get('csrftoken')};
 
         form.append('dest', dest)
         form.append('name', file.name)
@@ -201,38 +205,38 @@ const SparkMD5 = require('spark-md5');
         })
     }
 
-    var removeUpload = function(e) {
+    const removeUpload = function (e) {
         e.preventDefault()
 
-        var el = e.target.parentElement
+        const el = e.target.parentElement
         el.querySelector('.file-url').value = ''
         el.querySelector('.file-input').value = ''
         el.className = 's3direct form-active'
-    }
+    };
 
-    var addHandlers = function(el) {
+    const addHandlers = function (el) {
         console.log('Adding django-s3direct handlers…');
-        var url    = el.querySelector('.file-url'),
-            input  = el.querySelector('.file-input'),
-            remove = el.querySelector('.file-remove'),
-            status = (url.value === '') ? 'form' : 'link'
+        const url = el.querySelector('.file-url'),
+              input = el.querySelector('.file-input'),
+              remove = el.querySelector('.file-remove'),
+              status = (url.value === '') ? 'form' : 'link';
 
         el.className = 's3direct ' + status + '-active'
 
         remove.addEventListener('click', removeUpload, false)
         input.addEventListener('change', checkFileAndInitiateUpload, false)
-    }
+    };
 
-    document.addEventListener('DOMContentLoaded', function(e) {
-        ;[].forEach.call(document.querySelectorAll('.s3direct'), addHandlers)
-    })
+    document.addEventListener('DOMContentLoaded', function(event) {
+        [].forEach.call(document.querySelectorAll('.s3direct'), addHandlers)
+    });
 
-    document.addEventListener('DOMNodeInserted', function(e){
-        if(e.target.tagName) {
-            var el = e.target.querySelectorAll('.s3direct');
+    document.addEventListener('DOMNodeInserted', function(event){
+        if(event.target.tagName) {
+            const el = event.target.querySelectorAll('.s3direct');
             [].forEach.call(el, function (element, index, array) {
-		addHandlers(element);
-	    });
+                addHandlers(element);
+            });
         }
     })
 

--- a/s3direct/templates/s3direct/s3direct-widget.tpl
+++ b/s3direct/templates/s3direct/s3direct-widget.tpl
@@ -1,4 +1,4 @@
-<div class="s3direct" data-policy-url="{{ policy_url }}">
+<div class="s3direct" data-policy-url="{{ policy_url }}" data-signing-url="{{ signing_url }}">
   <a class="file-link" target="_blank" href="{{ file_url }}">{{ file_name }}</a>
   <a class="file-remove" href="#remove">Remove</a>
   <input class="file-url" type="hidden" value="{{ file_url }}" id="{{ element_id }}" name="{{ name }}" />

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -146,9 +146,10 @@ class WidgetTestCase(TestCase):
         self.assertEqual(policy_dict['server_side_encryption'], u'AES256')
 
 
+@override_settings(AWS_ACCESS_KEY_ID='abc', AWS_SECRET_ACCESS_KEY='123')
 class SignatureViewTestCase(TestCase):
     EXAMPLE_SIGNING_DATE = datetime(2017, 4, 6, 8, 30)
-    EXPECTED_SIGNATURE = b'5d8755e65140f66cff5ea78a0454177c366fa1ebaa4f87bd9df673a62c41f966'
+    EXPECTED_SIGNATURE = b'76ea6730e10ddc9d392f40bf64872ddb1728cab58301dccb9efb67cb560a9272'
 
     def setUp(self):
         admin = User.objects.create_superuser('admin', 'u@email.com', 'admin')

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -52,13 +52,6 @@ TEST_DESTINATIONS = {
 
 @override_settings(S3DIRECT_DESTINATIONS=TEST_DESTINATIONS)
 class WidgetTestCase(TestCase):
-    """
-    This allows us to have 2 version of the same tests but with different
-    settings. As opposed to inheriting test methods as doing that makes the
-    failure stack hard to parse.
-    TODO: Get rid of this base class and the appropriate subclass when
-    positional setting support is dropped. See #48
-    """
 
     def setUp(self):
         admin = User.objects.create_superuser('admin', 'u@email.com', 'admin')

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -1,17 +1,16 @@
 import json
-from base64 import b64decode
 
 from django.conf import settings
-from django.test.utils import override_settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse, resolve
+from django.core.urlresolvers import resolve, reverse
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from s3direct import widgets
 
 
 HTML_OUTPUT = (
-    '<div class="s3direct" data-policy-url="/get_upload_params/">\n'
+    '<div class="s3direct" data-policy-url="/get_upload_params/" data-signing-url="/get_aws_v4_signature/">\n'
     '  <a class="file-link" target="_blank" href=""></a>\n'
     '  <a class="file-remove" href="#remove">Remove</a>\n'
     '  <input class="file-url" type="hidden" value="" id="" name="filename" />'
@@ -24,16 +23,30 @@ HTML_OUTPUT = (
     '</div>\n'
 )
 
-FOO_RESPONSE = {
-    u'x-amz-algorithm': u'AWS4-HMAC-SHA256',
-    u'form_action': u'https://s3.amazonaws.com/{}'.format(settings.AWS_STORAGE_BUCKET_NAME),
-    u'success_action_status': 201,
-    u'acl': u'public-read',
-    u'key': u'uploads/imgs/${filename}',
-    u'content-type': u'image/jpeg'
+POLICY_RESPONSE = {
+    u'object_key': u'uploads/imgs/${filename}',
+    u'content-type': u'image/jpeg',
+    u'access_key_id': settings.AWS_ACCESS_KEY_ID,
+    u'region': settings.S3DIRECT_REGION,
+    u'bucket': 'astoragebucketname',
+    u'bucket_url': 'https://s3.amazonaws.com/astoragebucketname',
+    u'cache_control': None,
+    u'content_disposition': None,
+    u'acl': 'public-read',
+    u'server_side_encryption': None,
 }
 
 
+@override_settings(S3DIRECT_DESTINATIONS={
+    'misc': {'key': lambda original_filename: 'images/unique.jpg'},
+    'files': {'key': 'uploads/files', 'auth': lambda u: u.is_staff},
+    'imgs': {'key': 'uploads/imgs', 'auth': lambda u: True, 'allowed': ['image/jpeg', 'image/png']},
+    'thumbs': {'key': 'uploads/thumbs', 'allowed': ['image/jpeg'], 'content_length_range': (1000, 50000)},
+    'vids': {'key': 'uploads/vids', 'auth': lambda u: u.is_authenticated(), 'allowed': ['video/mp4']},
+    'cached': {'key': 'uploads/vids', 'auth': lambda u: u.is_authenticated(), 'allowed': '*',
+               'acl': 'authenticated-read', 'bucket': 'astoragebucketname', 'cache_control': 'max-age=2592000',
+               'content_disposition': 'attachment', 'server_side_encryption': 'AES256'},
+})
 class WidgetTestCase(TestCase):
     """
     This allows us to have 2 version of the same tests but with different
@@ -47,198 +60,94 @@ class WidgetTestCase(TestCase):
         admin = User.objects.create_superuser('admin', 'u@email.com', 'admin')
         admin.save()
 
-    def check_urls(self):
+    def test_urls(self):
         reversed_url = reverse('s3direct')
         resolved_url = resolve('/get_upload_params/')
         self.assertEqual(reversed_url, '/get_upload_params/')
         self.assertEqual(resolved_url.view_name, 's3direct')
 
-    def check_widget_html(self):
+    def test_widget_html(self):
         widget = widgets.S3DirectWidget(dest='foo')
         self.assertEqual(widget.render('filename', None), HTML_OUTPUT)
 
-    def check_signing_logged_in(self):
+    def test_get_upload_parameters_logged_in(self):
         self.client.login(username='admin', password='admin')
-        data = {'dest': 'files', 'name': 'image.jpg', 'type': 'image/jpeg'}
+        data = {'dest': 'files', 'name': 'image.jpg', 'type': 'image/jpeg', 'size': 1000}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 200)
 
-    def check_signing_logged_out(self):
-        data = {'dest': 'files', 'name': 'image.jpg', 'type': 'image/jpeg'}
+    def test_get_upload_parameters_logged_out(self):
+        data = {'dest': 'files', 'name': 'image.jpg', 'type': 'image/jpeg', 'size': 1000}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 403)
 
-    def check_allowed_type(self):
-        data = {'dest': 'imgs', 'name': 'image.jpg', 'type': 'image/jpeg'}
+    def test_allowed_type(self):
+        data = {'dest': 'imgs', 'name': 'image.jpg', 'type': 'image/jpeg', 'size': 1000}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 200)
 
-    def check_disallowed_type(self):
-        data = {'dest': 'imgs', 'name': 'image.mp4', 'type': 'video/mp4'}
+    def test_disallowed_type(self):
+        data = {'dest': 'imgs', 'name': 'image.mp4', 'type': 'video/mp4', 'size': 1000}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 400)
 
-    def check_allowed_type_logged_in(self):
-        self.client.login(username='admin', password='admin')
-        data = {'dest': 'vids', 'name': 'video.mp4', 'type': 'video/mp4'}
+    def test_allowed_size(self):
+        data = {'dest': 'thumbs', 'name': 'thumbnail.jpg', 'type': 'image/jpeg', 'size': 20000}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 200)
 
-    def check_disallowed_type_logged_out(self):
-        data = {u'dest': u'vids', u'name': u'video.mp4', u'type': u'video/mp4'}
+    def test_disallowed_size(self):
+        data = {'dest': 'thumbs', 'name': 'thumbnail.jpg', 'type': 'image/jpeg', 'size': 200000}
+        response = self.client.post(reverse('s3direct'), data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_allowed_type_logged_in(self):
+        self.client.login(username='admin', password='admin')
+        data = {'dest': 'vids', 'name': 'video.mp4', 'type': 'video/mp4', 'size': 1000}
+        response = self.client.post(reverse('s3direct'), data)
+        self.assertEqual(response.status_code, 200)
+
+    def test_disallowed_type_logged_out(self):
+        data = {u'dest': u'vids', u'name': u'video.mp4', u'type': u'video/mp4', 'size': 1000}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 403)
 
-    def check_signing_fields(self):
-        self.client.login(username='admin', password='admin')
-        data = {u'dest': u'imgs', u'name': u'image.jpg',
-                u'type': u'image/jpeg'}
-        response = self.client.post(reverse('s3direct'), data)
-        response_dict = json.loads(response.content.decode())
-        self.assertTrue(u'x-amz-signature' in response_dict)
-        self.assertTrue(u'x-amz-credential' in response_dict)
-        self.assertTrue(u'policy' in response_dict)
-        self.assertDictContainsSubset(FOO_RESPONSE, response_dict)
+    # TODO: test object key functions
+    def test_default_upload_key(self):
+        pass
 
-    def check_signing_fields_unique_filename(self):
-        data = {u'dest': u'misc', u'name': u'image.jpg',
-                u'type': u'image/jpeg'}
-        response = self.client.post(reverse('s3direct'), data)
-        response_dict = json.loads(response.content.decode())
-        self.assertTrue(u'x-amz-signature' in response_dict)
-        self.assertTrue(u'x-amz-credential' in response_dict)
-        self.assertTrue(u'policy' in response_dict)
-        changed = FOO_RESPONSE.copy()
-        changed['key'] = 'images/unique.jpg'
-        self.assertDictContainsSubset(changed, response_dict)
+    def test_directory_object_key(self):
+        pass
 
-    def check_policy_conditions(self):
-        self.client.login(username='admin', password='admin')
-        data = {u'dest': u'cached', u'name': u'video.mp4',
-                u'type': u'video/mp4'}
-        response = self.client.post(reverse('s3direct'), data)
-        self.assertEqual(response.status_code, 200)
-        response_dict = json.loads(response.content.decode())
-        self.assertTrue('policy' in response_dict)
-        policy_dict = json.loads(
-                b64decode(response_dict['policy']).decode('utf-8'))
-        self.assertTrue('conditions' in policy_dict)
-        conditions_dict = policy_dict['conditions']
-        self.assertEqual(
-                conditions_dict[0]['bucket'], u'astoragebucketname')
-        self.assertEqual(
-                conditions_dict[1]['acl'], u'authenticated-read')
-        self.assertEqual(
-                conditions_dict[8]['Cache-Control'], u'max-age=2592000')
-        self.assertEqual(
-                conditions_dict[9]['Content-Disposition'], u'attachment')
-        self.assertEqual(
-                conditions_dict[10]['x-amz-server-side-encryption'], u'AES256')
-
-
-@override_settings(S3DIRECT_DESTINATIONS={
-    'misc': (lambda original_filename: 'images/unique.jpg',),
-    'files': ('uploads/files', lambda u: u.is_staff,),
-    'imgs': ('uploads/imgs', lambda u: True, ['image/jpeg', 'image/png'],),
-    'vids': ('uploads/vids', lambda u: u.is_authenticated(), ['video/mp4'],),
-    'cached': ('uploads/vids', lambda u: u.is_authenticated(), '*',
-               'authenticated-read', 'astoragebucketname', 'max-age=2592000',
-               'attachment', 'AES256'),
-})
-class OldStyleSettingsWidgetTest(WidgetTestCase):
-    """
-    Test coverage for the older "positional" style of specifying settings.
-    TODO: Remove me when positional settings are no longer supported.
-    """
-
-    def setUp(self):
-        super(OldStyleSettingsWidgetTest, self).setUp()
-
-    def test_urls(self):
-        self.check_urls()
-
-    def test_widget_html(self):
-        self.check_widget_html()
-
-    def test_signing_logged_in(self):
-        self.check_signing_logged_in()
-
-    def test_signing_logged_out(self):
-        self.check_signing_logged_out()
-
-    def test_allowed_type(self):
-        self.check_allowed_type()
-
-    def test_disallowed_type(self):
-        self.check_disallowed_type()
-
-    def test_allowed_type_logged_in(self):
-        self.check_allowed_type_logged_in()
-
-    def test_disallowed_type_logged_out(self):
-        self.check_disallowed_type_logged_out()
-
-    def test_signing_fields(self):
-        self.check_signing_fields()
-
-    def test_signing_fields_unique_filename(self):
-        self.check_signing_fields_unique_filename()
+    def test_function_object_key(self):
+        pass
 
     def test_policy_conditions(self):
-        self.check_policy_conditions()
-
-
-class WidgetTest(WidgetTestCase):
-
-    def setUp(self):
-        super(WidgetTest, self).setUp()
-
-    def test_urls(self):
-        self.check_urls()
-
-    def test_widget_html(self):
-        self.check_widget_html()
-
-    def test_signing_logged_in(self):
-        self.check_signing_logged_in()
-
-    def test_signing_logged_out(self):
-        self.check_signing_logged_out()
-
-    def test_allowed_type(self):
-        self.check_allowed_type()
-
-    def test_disallowed_type(self):
-        self.check_disallowed_type()
-
-    def test_allowed_type_logged_in(self):
-        self.check_allowed_type_logged_in()
-
-    def test_disallowed_type_logged_out(self):
-        self.check_disallowed_type_logged_out()
-
-    def test_signing_fields(self):
-        self.check_signing_fields()
-
-    def test_signing_fields_unique_filename(self):
-        self.check_signing_fields_unique_filename()
-
-    def test_policy_conditions(self):
-        self.check_policy_conditions()
-
-    """Tests for features only available with new-style settings"""
-    def test_content_length_range(self):
-        # Content_length_range setting is always sent as part of policy.
-        # Initial request data doesn't affect it.
-        data = {'dest': 'imgs', 'name': 'image.jpg', 'type': 'image/jpeg'}
+        self.client.login(username='admin', password='admin')
+        data = {u'dest': u'cached', u'name': u'video.mp4', u'type': u'video/mp4', 'size': 1000}
         response = self.client.post(reverse('s3direct'), data)
         self.assertEqual(response.status_code, 200)
+        policy_dict = json.loads(response.content.decode())
+        self.assertEqual(policy_dict['bucket'], u'astoragebucketname')
+        self.assertEqual(policy_dict['acl'], u'authenticated-read')
+        self.assertEqual(policy_dict['cache_control'], u'max-age=2592000')
+        self.assertEqual(policy_dict['content_disposition'], u'attachment')
+        self.assertEqual(policy_dict['server_side_encryption'], u'AES256')
 
-        response_dict = json.loads(response.content.decode())
-        self.assertTrue('policy' in response_dict)
-        policy_dict = json.loads(
-                b64decode(response_dict['policy']).decode('utf-8'))
-        self.assertTrue('conditions' in policy_dict)
-        conditions_dict = policy_dict['conditions']
-        self.assertEqual(
-                conditions_dict[-1], ['content-length-range', 5000, 20000000])
+
+class SignatureViewTestCase(TestCase):
+    def setUp(self):
+        admin = User.objects.create_superuser('admin', 'u@email.com', 'admin')
+        admin.save()
+
+    def test_expected_signature(self):
+        # TODO - generate base64 encoding of a policy document and expected signature
+        pass
+
+    def test_signing_logged_in(self):
+        pass
+
+    def test_signing_logged_out(self):
+        pass
+
+    # TODO - test CSRF requirement

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -1,6 +1,7 @@
 import json
 from base64 import b64decode
 
+from django.conf import settings
 from django.test.utils import override_settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse, resolve
@@ -25,7 +26,7 @@ HTML_OUTPUT = (
 
 FOO_RESPONSE = {
     u'x-amz-algorithm': u'AWS4-HMAC-SHA256',
-    u'form_action': u'https://s3.amazonaws.com/test-bucket',
+    u'form_action': u'https://s3.amazonaws.com/{}'.format(settings.AWS_STORAGE_BUCKET_NAME),
     u'success_action_status': 201,
     u'acl': u'public-read',
     u'key': u'uploads/imgs/${filename}',

--- a/s3direct/urls.py
+++ b/s3direct/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
-from s3direct.views import get_upload_params
+from s3direct.views import get_upload_params, generate_aws_v4_signature
+
 
 urlpatterns = [
-    url('^get_upload_params/', get_upload_params, name='s3direct')
+    url('^get_upload_params/', get_upload_params, name='s3direct'),
+    url('^get_aws_v4_signature/', generate_aws_v4_signature, name='s3direct-signing'),
 ]

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -47,7 +47,7 @@ def get_s3direct_destinations():
 # AWS Signature v4 Key derivation functions. See:
 # http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html#signature-v4-examples-python
 
-def sign(key: bytes, message: str):
+def sign(key, message):
     return hmac.new(key, message.encode("utf-8"), hashlib.sha256).digest()
 
 

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -12,36 +12,12 @@ def get_at(index, t):
     return value
 
 
-# NOTE: Don't use constant as it will break ability to change at runtime
-# (E.g. tests)
 def get_s3direct_destinations():
-    """Returns s3direct destinations, converting old format if necessary."""
-    destinations = getattr(settings, 'S3DIRECT_DESTINATIONS', None)
-    if destinations is None:
-        return None
+    """Returns s3direct destinations.
 
-    # TODO: Remove when older "positional" settings are no longer supported
-    converted_destinations = {}
-    key_mapping = {
-        0: 'key',
-        1: 'auth',
-        2: 'allowed',
-        3: 'acl',
-        4: 'bucket',
-        5: 'cache_control',
-        6: 'content_disposition',
-        7: 'server_side_encryption',
-    }
-    if destinations:
-        for dest, dest_value in destinations.items():
-            if type(dest_value) is tuple or type(dest_value) is list:
-                converted_destinations[dest] = {}
-                for index, key_name in key_mapping.items():
-                    converted_destinations[dest][key_name] = get_at(
-                            index, dest_value)
-            else:
-                converted_destinations[dest] = dest_value
-    return converted_destinations
+    NOTE: Don't use constant as it will break ability to change at runtime (e.g. tests)
+    """
+    return getattr(settings, 'S3DIRECT_DESTINATIONS', None)
 
 
 # AWS Signature v4 Key derivation functions. See:

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -1,8 +1,5 @@
 import hashlib
 import hmac
-import json
-from datetime import datetime, timedelta
-from base64 import b64encode
 
 from django.conf import settings
 
@@ -44,114 +41,24 @@ def get_s3direct_destinations():
                             index, dest_value)
             else:
                 converted_destinations[dest] = dest_value
-
     return converted_destinations
 
-def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
-                       content_disposition=None, content_length_range=None,
-                       server_side_encryption=None, access_key=None, secret_access_key=None, token=None):
 
-    bucket = bucket or settings.AWS_STORAGE_BUCKET_NAME
-    region = getattr(settings, 'S3DIRECT_REGION', None)
-    if not region or region == 'us-east-1':
-        endpoint = 's3.amazonaws.com'
-    else:
-        endpoint = 's3-%s.amazonaws.com' % region
-    expires_in = datetime.utcnow() + timedelta(seconds=60*5)
-    expires = expires_in.strftime('%Y-%m-%dT%H:%M:%S.000Z')
-    now_date = datetime.utcnow().strftime('%Y%m%dT%H%M%S000Z')
-    raw_date = datetime.utcnow().strftime('%Y%m%d')
+# AWS Signature v4 Key derivation functions. See:
+# http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html#signature-v4-examples-python
 
-    policy_dict = {
-            "expiration": expires,
-            "conditions": [
-                {"bucket": bucket},
-                {"acl": acl},
-                ["starts-with", "$key", ''],
-                {"success_action_status": '201'},
-                {"x-amz-credential": '%s/%s/%s/s3/aws4_request' % (
-                    access_key,
-                    raw_date, region
-                )},
-                {"x-amz-algorithm": "AWS4-HMAC-SHA256"},
-                {"x-amz-date": now_date},
-                {"content-type": content_type},
-            ]
-        }
+def sign(key: bytes, message: str):
+    return hmac.new(key, message.encode("utf-8"), hashlib.sha256).digest()
 
-    if token:
-        policy_dict["conditions"].append({"x-amz-security-token": token})
 
-    if cache_control:
-        policy_dict['conditions'].append({'Cache-Control': cache_control})
+def get_aws_v4_signing_key(key, signing_date, region, service):
+    datestamp = signing_date.strftime('%Y%m%d')
+    date_key = sign(('AWS4' + key).encode('utf-8'), datestamp)
+    k_region = sign(date_key, region)
+    k_service = sign(k_region, service)
+    k_signing = sign(k_service, 'aws4_request')
+    return k_signing
 
-    if content_disposition:
-        policy_dict['conditions'].append({
-            'Content-Disposition': content_disposition
-        })
 
-    if server_side_encryption:
-        policy_dict['conditions'].append(
-            {'x-amz-server-side-encryption': server_side_encryption}
-        )
-
-    if content_length_range:
-        policy_dict['conditions'].append(
-            [
-                'content-length-range',
-                content_length_range[0],
-                content_length_range[1]
-            ]
-        )
-
-    policy_object = json.dumps(policy_dict)
-
-    policy = b64encode(
-        policy_object.replace('\n', '').replace('\r', '').encode())
-
-    date_key = hmac.new(b'AWS4' + secret_access_key.encode('utf-8'),
-                        msg=raw_date.encode('utf-8'),
-                        digestmod=hashlib.sha256).digest()
-
-    date_region_key = hmac.new(date_key, msg=region.encode('utf-8'),
-                               digestmod=hashlib.sha256).digest()
-
-    date_region_service_key = hmac.new(date_region_key, msg=b's3',
-                                       digestmod=hashlib.sha256).digest()
-
-    signing_key = hmac.new(date_region_service_key, msg=b'aws4_request',
-                           digestmod=hashlib.sha256).digest()
-
-    signature = hmac.new(signing_key, msg=policy,
-                         digestmod=hashlib.sha256).hexdigest()
-
-    structure = getattr(settings, 'S3DIRECT_URL_STRUCTURE', 'https://{0}/{1}')
-    bucket_url = structure.format(endpoint, bucket)
-
-    return_dict = {
-        # FIXME: .decode() does nothing, b64decode works but is decoding
-        # really intended?
-        "policy": policy.decode(),
-        "success_action_status": 201,
-        "x-amz-credential": "%s/%s/%s/s3/aws4_request" % (
-            access_key, raw_date, region
-        ),
-        "x-amz-date": now_date,
-        "x-amz-signature": signature,
-        "x-amz-algorithm": "AWS4-HMAC-SHA256",
-        "form_action": bucket_url,
-        "key": key,
-        "acl": acl,
-        "content-type": content_type
-    }
-
-    if token:
-        return_dict['x-amz-security-token'] = token
-
-    if cache_control:
-        return_dict['Cache-Control'] = cache_control
-
-    if content_disposition:
-        return_dict['Content-Disposition'] = content_disposition
-
-    return return_dict
+def get_aws_v4_signature(key, message):
+    return hmac.new(key, message.encode('utf-8'), hashlib.sha256).hexdigest()

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -5,11 +5,13 @@ from urllib.parse import unquote
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound, \
     HttpResponseServerError
+from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST
 
 from .utils import get_aws_v4_signature, get_aws_v4_signing_key, get_s3direct_destinations
 
 
+@csrf_protect
 @require_POST
 def get_upload_params(request):
     """Authorises user and validates given file properties."""
@@ -73,6 +75,7 @@ def get_upload_params(request):
     return HttpResponse(json.dumps(upload_data), content_type='application/json')
 
 
+@csrf_protect
 @require_POST
 def generate_aws_v4_signature(request):
     message = unquote(request.POST['to_sign'])

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -1,86 +1,84 @@
 import json
+from datetime import datetime
+from urllib.parse import unquote
 
-from django.http import HttpResponse
-from django.views.decorators.http import require_POST
 from django.conf import settings
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound, \
+    HttpResponseServerError
+from django.views.decorators.http import require_POST
 
-from .utils import create_upload_data, get_s3direct_destinations
+from .utils import get_aws_v4_signature, get_aws_v4_signing_key, get_s3direct_destinations
 
 
 @require_POST
 def get_upload_params(request):
-    content_type = request.POST['type']
-    filename = request.POST['name']
-
+    """Authorises user and validates given file properties."""
+    file_name = request.POST['name']
+    file_type = request.POST['type']
+    file_size = int(request.POST['size'])
     dest = get_s3direct_destinations().get(request.POST['dest'])
-
     if not dest:
-        data = json.dumps({'error': 'File destination does not exist.'})
-        return HttpResponse(data, content_type="application/json", status=400)
+        return HttpResponseNotFound(json.dumps({'error': 'File destination does not exist.'}),
+                                    content_type='application/json')
 
-    key = dest.get('key')
-    auth = dest.get('auth')
+    # Validate request and destination config:
     allowed = dest.get('allowed')
-    acl = dest.get('acl')
-    bucket = dest.get('bucket')
-    cache_control = dest.get('cache_control')
-    content_disposition = dest.get('content_disposition')
+    auth = dest.get('auth')
+    key = dest.get('key')
     content_length_range = dest.get('content_length_range')
-    server_side_encryption = dest.get('server_side_encryption')
-
-    if not acl:
-        acl = 'public-read'
-
-    if not key:
-        data = json.dumps({'error': 'Missing destination path.'})
-        return HttpResponse(data, content_type="application/json", status=403)
 
     if auth and not auth(request.user):
-        data = json.dumps({'error': 'Permission denied.'})
-        return HttpResponse(data, content_type="application/json", status=403)
+        return HttpResponseForbidden(json.dumps({'error': 'Permission denied.'}), content_type='application/json')
 
-    if (allowed and content_type not in allowed) and allowed != '*':
-        data = json.dumps({'error': 'Invalid file type (%s).' % content_type})
-        return HttpResponse(data, content_type="application/json", status=400)
+    if (allowed and file_type not in allowed) and allowed != '*':
+        return HttpResponseBadRequest(json.dumps({'error': 'Invalid file type (%s).' % file_type}),
+                                      content_type='application/json')
 
-    if hasattr(key, '__call__'):
-        key = key(filename)
+    if content_length_range and not content_length_range[0] <= file_size <= content_length_range[1]:
+        return HttpResponseBadRequest(
+            json.dumps({'error': 'Invalid file size (must be between %s and %s bytes).' % content_length_range}),
+            content_type='application/json')
+
+    # Generate object key
+    if not key:
+        return HttpResponseServerError(json.dumps({'error': 'Missing destination path.'}),
+                                       content_type='application/json')
+    elif hasattr(key, '__call__'):
+        object_key = key(file_name)
     elif key == '/':
-        key = '${filename}'
-    else:
         # The literal string '${filename}' is an S3 field variable for key.
         # https://aws.amazon.com/articles/1434#aws-table
-        key = '%s/${filename}' % key
+        object_key = '${filename}'
+    else:
+        object_key = '%s/${filename}' % key
 
-    access_key = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
-    secret_access_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
-    token = None
+    bucket = dest.get('bucket') or settings.AWS_STORAGE_BUCKET_NAME
+    region = dest.get('region') or getattr(settings, 'S3DIRECT_REGION', None) or 'us-east-1'
+    endpoint = 's3.amazonaws.com' if region == 'us-east-1' else ('s3-%s.amazonaws.com' % region)
 
-    if access_key is None or secret_access_key is None:
-        # Get credentials from instance profile if not defined in settings --
-        # this avoids the need to put access credentials in the settings.py file.
-        # Assumes we're running on EC2.
+    # AWS credentials are not required for publicly-writable buckets
+    access_key_id = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
 
-        try:
-            from botocore.credentials import InstanceMetadataProvider, InstanceMetadataFetcher
-        except ImportError:
-            InstanceMetadataProvider = None
-            InstanceMetadataFetcher = None
+    bucket_url = 'https://{0}/{1}'.format(endpoint, bucket)
 
-        if all([InstanceMetadataProvider, InstanceMetadataFetcher]):
-            provider = InstanceMetadataProvider(iam_role_fetcher=InstanceMetadataFetcher(timeout=1000, num_attempts=2))
-            creds = provider.load()
-            access_key = creds.access_key
-            secret_access_key = creds.secret_key
-            token = creds.token
-        else:
-            data = json.dumps({'error': 'Failed to access EC2 instance metadata due to missing dependency.'})
-            return HttpResponse(data, content_type="application/json", status=500)
+    upload_data = {
+        'object_key': object_key,
+        'access_key_id': access_key_id,
+        'region': region,
+        'bucket': bucket,
+        'bucket_url': bucket_url,
+        'cache_control': dest.get('cache_control'),
+        'content_disposition': dest.get('content_disposition'),
+        'acl': dest.get('acl') or 'public-read',
+        'server_side_encryption': dest.get('server_side_encryption'),
+    }
+    return HttpResponse(json.dumps(upload_data), content_type='application/json')
 
 
-    data = create_upload_data(
-        content_type, key, acl, bucket, cache_control, content_disposition,
-        content_length_range, server_side_encryption, access_key, secret_access_key, token
-    )
-
-    return HttpResponse(json.dumps(data), content_type="application/json")
+@require_POST
+def generate_aws_v4_signature(request):
+    message = unquote(request.POST['to_sign'])
+    signing_date = datetime.strptime(request.POST['datetime'], '%Y%m%dT%H%M%SZ')
+    signing_key = get_aws_v4_signing_key(settings.AWS_SECRET_ACCESS_KEY, signing_date, settings.S3DIRECT_REGION, 's3')
+    signature = get_aws_v4_signature(signing_key, message)
+    return HttpResponse(signature)

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -1,6 +1,9 @@
 import json
 from datetime import datetime
-from urllib.parse import unquote
+try:
+    from urllib.parse import unquote
+except ImportError:
+    from urlparse import unquote
 
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound, \

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -46,11 +46,9 @@ def get_upload_params(request):
     elif hasattr(key, '__call__'):
         object_key = key(file_name)
     elif key == '/':
-        # The literal string '${filename}' is an S3 field variable for key.
-        # https://aws.amazon.com/articles/1434#aws-table
-        object_key = '${filename}'
+        object_key = file_name
     else:
-        object_key = '%s/${filename}' % key
+        object_key = '%s/%s' % (key, file_name)
 
     bucket = dest.get('bucket') or settings.AWS_STORAGE_BUCKET_NAME
     region = dest.get('region') or getattr(settings, 'S3DIRECT_REGION', None) or 'us-east-1'

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -53,7 +53,7 @@ def get_upload_params(request):
     elif key == '/':
         object_key = file_name
     else:
-        object_key = '%s/%s' % (key, file_name)
+        object_key = '%s/%s' % (key.strip('/'), file_name)
 
     bucket = dest.get('bucket') or settings.AWS_STORAGE_BUCKET_NAME
     region = dest.get('region') or getattr(settings, 'S3DIRECT_REGION', None) or 'us-east-1'

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -34,6 +34,7 @@ class S3DirectWidget(widgets.TextInput):
         tpl = os.path.join('s3direct', 's3direct-widget.tpl')
         output = render_to_string(tpl, {
             'policy_url': reverse('s3direct'),
+            'signing_url': reverse('s3direct-signing'),
             'element_id': self.build_attrs(attrs).get('id', '') if attrs else '',
             'file_name': file_name,
             'dest': self.dest,

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -12,7 +12,7 @@ class S3DirectWidget(widgets.TextInput):
 
     class Media:
         js = (
-            's3direct/js/scripts.js',
+            's3direct/js/bundled.js',
         )
         css = {
             'all': (

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='django-s3direct',
-    version='0.4.11',
+    version='0.4.11.multipart-upload.3',
     description=('Add direct uploads to S3 functionality with a progress bar'
                  ' to file input fields.'),
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='django-s3direct',
-    version='0.4.11.multipart-upload.3',
+    version='1.0.0.dev1',
     description=('Add direct uploads to S3 functionality with a progress bar'
                  ' to file input fields.'),
     long_description=readme,


### PR DESCRIPTION
Fixes #105.

- Removed policy and signature generation from `s3direct` endpoint, adding more file information.
- Require bundling [EvaporateJS](https://github.com/TTLabs/EvaporateJS) to provide multipart upload.
- Added `s3direct-signing` endpoint to sign messages from EvaporateJS.

This is a large change that I've put together to support [S3 multipart file upload](http://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html) so that we can upload objects (mostly videos) larger than the 5GB `POST` limit.

This isn't a breaking change, but the internals have been heavily stripped, a second endpoint has been added, and NPM is required to bundle the required JS libraries for packaging. This also means that the project isn't usable until the bundle is built.

It may be better to simply add the JS bundle to source control but the final file is ~6kloc, swamping the rest of the source. However this *would* allow installation via Pip's `--editable`/`-e` mode from GitHub.

## Pre-release wheel

A pre-release wheel for testing is available from [here](https://github.com/boilerroomtv/django-s3direct/releases/tag/v0.4.10%2Bmultipart-upload.1):

```sh
pip install 'https://github.com/boilerroomtv/django-s3direct/releases/download/v0.4.10%2Bmultipart-upload.1/django_s3direct-0.4.10.multipart.1-py3-none-any.whl'
```

## Building the JavaScript bundle:

```sh
npm build
```