### PR TITLE
Use CSRF cookie name setting for cookie lookup

### DIFF
--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -168,10 +168,11 @@ const SparkMD5 = require('spark-md5');
         const element             = event.target.parentElement,
               file                = element.querySelector('.file-input').files[0],
               dest                = element.querySelector('.file-dest').value,
+              csrfTokenName       = element.querySelector('.csrf-cookie-name').value,
               destinationCheckUrl = element.getAttribute('data-policy-url'),
               signerUrl           = element.getAttribute('data-signing-url'),
               form                = new FormData(),
-              headers             = {'X-CSRFToken': Cookies.get('csrftoken')};
+              headers             = {'X-CSRFToken': Cookies.get(csrfTokenName)};
 
         form.append('dest', dest)
         form.append('name', file.name)

--- a/s3direct/templates/s3direct/s3direct-widget.tpl
+++ b/s3direct/templates/s3direct/s3direct-widget.tpl
@@ -1,6 +1,7 @@
 <div class="s3direct" data-policy-url="{{ policy_url }}" data-signing-url="{{ signing_url }}">
   <a class="file-link" target="_blank" href="{{ file_url }}">{{ file_name }}</a>
   <a class="file-remove" href="#remove">Remove</a>
+  <input class="csrf-cookie-name" type="hidden" value="{{ csrf_cookie_name }}">
   <input class="file-url" type="hidden" value="{{ file_url }}" id="{{ element_id }}" name="{{ name }}" />
   <input class="file-dest" type="hidden" value="{{ dest }}">
   <input class="file-input" type="file"  style="{{ style }}"/>

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -15,6 +15,7 @@ HTML_OUTPUT = (
     '<div class="s3direct" data-policy-url="/get_upload_params/" data-signing-url="/get_aws_v4_signature/">\n'
     '  <a class="file-link" target="_blank" href=""></a>\n'
     '  <a class="file-remove" href="#remove">Remove</a>\n'
+    '  <input class="csrf-cookie-name" type="hidden" value="csrftoken">\n'
     '  <input class="file-url" type="hidden" value="" id="" name="filename" />'
     '\n'
     '  <input class="file-dest" type="hidden" value="foo">\n'

--- a/s3direct/widgets.py
+++ b/s3direct/widgets.py
@@ -6,6 +6,7 @@ from django.utils.safestring import mark_safe
 from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 from django.utils.http import urlunquote_plus
+from django.conf import settings
 
 
 class S3DirectWidget(widgets.TextInput):
@@ -41,6 +42,7 @@ class S3DirectWidget(widgets.TextInput):
             'file_url': value or '',
             'name': name,
             'style': self.build_attrs(attrs).get('style', '') if attrs else '',
+            'csrf_cookie_name': getattr(settings, 'CSRF_COOKIE_NAME', 'csrftoken'),
         })
 
         return mark_safe(output)


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/ref/settings/#csrf-cookie-name

When customizing CSRF settings, encountered this issue when the name was changed.