### PR TITLE
Added support for args to be passed to key when it's callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ S3DIRECT_REGION = 'us-east-1'
 #     1. '/' = Upload to root with the original filename.
 #     2. 'some/path' = Upload to some/path with the original filename.
 #     3. functionName = Pass a function and create your own path/filename.
+# key_args [optional] Arguments to be passed to 'key' if it's a function.
 # auth [optional] An ACL function to whether the current Django user can perform this action.
 # allowed [optional] List of allowed MIME types.
 # acl [optional] Give the object another ACL rather than 'public-read'.
@@ -159,6 +160,10 @@ S3DIRECT_DESTINATIONS = {
         'content_disposition': 'attachment',  # Default no content disposition
         'content_length_range': (5000, 20000000), # Default allow any size
         'server_side_encryption': 'AES256', # Default no encryption
+    },
+    'example_other': {
+        'key': lambda filename, args: args + '/' filename,
+    	'key_args': 'uploads/images',  # Only if 'key' is a function
     }
 }
 ```

--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -58,6 +58,7 @@ TEST_DESTINATIONS = {
                'content_disposition': 'attachment', 'server_side_encryption': 'AES256'},
     'accidental-leading-slash': {'key': '/directory/leading'},
     'accidental-trailing-slash': {'key': 'directory/trailing/'},
+    'key_args': {'key': lambda original_filename, args: args + '/' +'background.jpg', 'key_args': 'assets/backgrounds'},
 }
 
 
@@ -161,6 +162,14 @@ class WidgetTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         policy_dict = json.loads(response.content.decode())
         self.assertNotEqual(policy_dict['object_key'], data['name'])
+
+    def test_function_object_key_with_args(self):
+        data = {'dest': 'key_args', 'name': 'background.jpg', 'type': 'image/jpeg', 'size': 1000}
+        self.client.login(username='admin', password='admin')
+        response = self.client.post(reverse('s3direct'), data)
+        self.assertEqual(response.status_code, 200)
+        policy_dict = json.loads(response.content.decode())
+        self.assertEqual(policy_dict['object_key'], TEST_DESTINATIONS['key_args']['key_args'] + '/' + data['name'])
 
     def test_policy_conditions(self):
         self.client.login(username='admin', password='admin')

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -38,3 +38,17 @@ def get_aws_v4_signing_key(key, signing_date, region, service):
 
 def get_aws_v4_signature(key, message):
     return hmac.new(key, message.encode('utf-8'), hashlib.sha256).hexdigest()
+
+
+def get_key(key, file_name, dest):
+    if hasattr(key, '__call__'):
+        fn_args = [file_name, ]
+        args = dest.get('key_args')
+        if args:
+            fn_args.append(args)
+        object_key = key(*fn_args)
+    elif key == '/':
+        object_key = file_name
+    else:
+        object_key = '%s/%s' % (key.strip('/'), file_name)
+    return object_key

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -11,7 +11,7 @@ from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbid
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST
 
-from .utils import get_aws_v4_signature, get_aws_v4_signing_key, get_s3direct_destinations
+from .utils import get_aws_v4_signature, get_aws_v4_signing_key, get_s3direct_destinations, get_key
 
 
 @csrf_protect
@@ -48,12 +48,8 @@ def get_upload_params(request):
     if not key:
         return HttpResponseServerError(json.dumps({'error': 'Missing destination path.'}),
                                        content_type='application/json')
-    elif hasattr(key, '__call__'):
-        object_key = key(file_name)
-    elif key == '/':
-        object_key = file_name
     else:
-        object_key = '%s/%s' % (key.strip('/'), file_name)
+        object_key = get_key(key, file_name, dest)
 
     bucket = dest.get('bucket') or settings.AWS_STORAGE_BUCKET_NAME
     region = dest.get('region') or getattr(settings, 'S3DIRECT_REGION', None) or 'us-east-1'


### PR DESCRIPTION
The user case for this change is that I want to generate the filename and also set a path like

In `settings.py`

```
def get_filename(file_name, args):
    return file_name + '/' + args

S3DIRECT_DESTINATIONS = {
    'assets:background': {
        'key': get_filename,
        'key_args', 'asset/background'
    },
```