### PR TITLE
correct syntax in README.md S3DIRECT_DESTINATIONS configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ S3DIRECT_DESTINATIONS = {
         'server_side_encryption': 'AES256', # Default no encryption
     },
     'example_other': {
-        'key': lambda filename, args: args + '/' filename,
+        'key': lambda filename, args: args + '/' + filename,
     	'key_args': 'uploads/images',  # Only if 'key' is a function
     }
 }


### PR DESCRIPTION
This fixes a tiny syntax error in the README.md's example for modifying setting.py with S3DIRECT_DESTINATIONS.
