### PR TITLE
Don't set optional params in JSON / Add ability to use functions in params

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ S3DIRECT_DESTINATIONS = {
         'bucket': 'pdf-bucket', # Default is 'AWS_STORAGE_BUCKET_NAME'
         'acl': 'private', # Defaults to 'public-read'
         'cache_control': 'max-age=2592000', # Default no cache-control
-        'content_disposition': 'attachment',  # Default no content disposition
+        'content_disposition': lambda x: 'attachment; filename="{}"'.format(x),  # Default no content disposition
         'content_length_range': (5000, 20000000), # Default allow any size
         'server_side_encryption': 'AES256', # Default no encryption
     },

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -66,11 +66,19 @@ def get_upload_params(request):
         'region': region,
         'bucket': bucket,
         'bucket_url': bucket_url,
-        'cache_control': dest.get('cache_control'),
-        'content_disposition': dest.get('content_disposition'),
         'acl': dest.get('acl') or 'public-read',
-        'server_side_encryption': dest.get('server_side_encryption'),
     }
+
+    optional_params = ['content_disposition', 'cache_control', 'server_side_encryption']
+
+    for optional_param in optional_params:
+        if optional_param in dest:
+            option = dest.get(optional_param)
+            if hasattr(option, '__call__'):
+                upload_data[optional_param] = option(file_name)
+            else:
+                upload_data[optional_param] = option
+
     return HttpResponse(json.dumps(upload_data), content_type='application/json')
 
 


### PR DESCRIPTION
If these params are undefined in settings they show up in S3 as 'null' values rather than the default 'undefined'.

```
Cache-Control: null
Content-Disposition: null
```

This also allows you to use the optional filename parameter