### PR TITLE
Fixed: {Content-Disposition: null} being set by default

### DIFF
--- a/s3direct/static/s3direct/js/bundled.js
+++ b/s3direct/static/s3direct/js/bundled.js
@@ -6018,6 +6018,14 @@ const SparkMD5 = require('spark-md5');
             return headers;
         };
 
+        const generateUnsignedHeaders = function (cacheControl, contentDisposition){
+            // Do not add Content-Disposition if it's not set
+            let headers = {};
+            headers['Cache-Control'] = cacheControl;
+            if (contentDisposition) headers['Content-Disposition'] = contentDisposition;
+            return headers;
+        };
+
         Evaporate.create(
             {
                 //signerUrl: signingUrl,
@@ -6041,7 +6049,7 @@ const SparkMD5 = require('spark-md5');
                 file: file,
                 contentType: file.type,
                 xAmzHeadersAtInitiate: generateAmazonHeaders(acl, serverSideEncryption),
-                notSignedHeadersAtInitiate: {'Cache-Control': cacheControl, 'Content-Disposition': contentDisposition},
+                notSignedHeadersAtInitiate: generateUnsignedHeaders(cacheControl, contentDisposition),
                 progress: function (progressRatio, stats) { updateProgressBar(element, progressRatio); },
             }).then(
                 function (awsS3ObjectKey) {

--- a/s3direct/static/s3direct/js/scripts.js
+++ b/s3direct/static/s3direct/js/scripts.js
@@ -128,6 +128,14 @@ const SparkMD5 = require('spark-md5');
             return headers;
         };
 
+        const generateUnsignedHeaders = function (cacheControl, contentDisposition) {
+            // Do not add Content-Disposition if it's not set
+            let headers = {};
+            headers['Cache-Control'] = cacheControl;
+            if (contentDisposition) headers['Content-Disposition'] = contentDisposition;
+            return headers;
+        };
+
         Evaporate.create(
             {
                 //signerUrl: signingUrl,
@@ -151,7 +159,7 @@ const SparkMD5 = require('spark-md5');
                 file: file,
                 contentType: file.type,
                 xAmzHeadersAtInitiate: generateAmazonHeaders(acl, serverSideEncryption),
-                notSignedHeadersAtInitiate: {'Cache-Control': cacheControl, 'Content-Disposition': contentDisposition},
+                notSignedHeadersAtInitiate: generateUnsignedHeaders(cacheControl, contentDisposition),
                 progress: function (progressRatio, stats) { updateProgressBar(element, progressRatio); },
             }).then(
                 function (awsS3ObjectKey) {


### PR DESCRIPTION
If `content_disposition` is not defined, `Content-Disposition: null` is set as default in the object's metadata. Hence, forcing image download instead of rendering them in the browser.