### PR TITLE
mark signature response as text/plain instead of html

### DIFF
--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -81,4 +81,4 @@ def generate_aws_v4_signature(request):
     signing_date = datetime.strptime(request.POST['datetime'], '%Y%m%dT%H%M%SZ')
     signing_key = get_aws_v4_signing_key(settings.AWS_SECRET_ACCESS_KEY, signing_date, settings.S3DIRECT_REGION, 's3')
     signature = get_aws_v4_signature(signing_key, message)
-    return HttpResponse(signature)
+    return HttpResponse(signature, content_type="text/plain")


### PR DESCRIPTION
I noticed this because I am using https://github.com/cobrateam/django-htmlmin which is minified this incorrectly since it's not html.