### PR TITLE
Corrected AWS_S3_ENDPOINT_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ AWS_S3_REGION_NAME = 'eu-west-1'
 
 # The endpoint of your bucket, more info:
 # http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-AWS_S3_ENDPOINT_URL = 'https://s3-eu-west-1.amazonaws.com'
+AWS_S3_ENDPOINT_URL = 'https://s3.eu-west-1.amazonaws.com'
 
 S3DIRECT_DESTINATIONS = {
     'example_destination': {


### PR DESCRIPTION
AWS_S3_ENDPOINT_URL = 'https://s3-eu-west-1.amazonaws.com' will throw a net::ERR_NAME_NOT_RESOLVED error, because the URL is invalid ref = https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region , the hyphen should be replaced with a period hence giving 'https://s3.eu-west-1.amazonaws.com'