### PR TITLE
Store botocore session between requests

### DIFF
--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -496,7 +496,7 @@ class SignatureViewTestCase(TestCase):
 
 
 class AWSCredentialsTest(TestCase):
-    @mock.patch('s3direct.utils.session')
+    @mock.patch('s3direct.utils.SESSION')
     @override_settings(AWS_ACCESS_KEY_ID=None, AWS_SECRET_ACCESS_KEY=None)
     def test_retrieves_aws_credentials_from_botocore(self, botocore_mock):
         credentials_mock = mock.Mock(
@@ -504,10 +504,9 @@ class AWSCredentialsTest(TestCase):
             secret_key='secret_key',
             access_key='access_key',
         )
-        botocore_mock.get_session(
-        ).get_credentials.return_value = credentials_mock
+        botocore_mock.get_credentials.return_value = credentials_mock
         credentials = get_aws_credentials()
-        botocore_mock.get_session().get_credentials.assert_called_once_with()
+        botocore_mock.get_credentials.assert_called_once_with()
         self.assertEqual(credentials.token, 'token')
         self.assertEqual(credentials.secret_key, 'secret_key')
         self.assertEqual(credentials.access_key, 'access_key')

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -16,7 +16,9 @@ except ImportError:
 
 AWSCredentials = namedtuple('AWSCredentials',
                             ['token', 'secret_key', 'access_key'])
-
+SESSION = None
+if session is not None:
+    SESSION=session.get_session()
 
 def get_s3direct_destinations():
     """Returns s3direct destinations.
@@ -70,11 +72,11 @@ def get_aws_credentials():
         # AWS tokens are not created for pregenerated access keys
         return AWSCredentials(None, secret_key, access_key)
 
-    if not session:
+    if not SESSION:
         # AWS credentials are not required for publicly-writable buckets
         return AWSCredentials(None, None, None)
 
-    creds = session.get_session().get_credentials()
+    creds = SESSION.get_credentials()
     if creds:
         return AWSCredentials(creds.token, creds.secret_key, creds.access_key)
     else:


### PR DESCRIPTION
With AWS STS every session has temporary credentials.
Credentials are valid for hour, but if new session object is created,
then new credentials are generated.

With current functionality using AWS STS is causing:
SignatureDoesNotMatch error.